### PR TITLE
feat: 프로필 페이지 배경색 및 Gnb 컴포넌트 variant 설정

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,10 +1,15 @@
+"use client";
 import Gnb from "@/components/gnb/gnb";
 import { Suspense } from "react";
+import { usePathname } from "next/navigation";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const isProfilePage = pathname === "/profile";
+
   return (
     <Suspense>
-      <Gnb />
+      <Gnb variant={isProfilePage ? "tertiary" : "default"} />
       {children}
     </Suspense>
   );

--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -1,6 +1,10 @@
-import { redirect } from "next/navigation";
-
-export default function Page() {
-  redirect("/login");
-  return <div></div>;
+export default function ProfilePage() {
+  return (
+    <div className="bg-tertiary-500 min-h-screen">
+      <div className="p-6">
+        <h1>프로필 페이지</h1>
+        <p>사용자 프로필 정보가 여기에 표시됩니다.</p>
+      </div>
+    </div>
+  );
 }

--- a/src/app/(main)/saved/_components/empty-saved-list.tsx
+++ b/src/app/(main)/saved/_components/empty-saved-list.tsx
@@ -14,11 +14,3 @@ export default function EmptySavedList() {
     </div>
   );
 }
-// color: var(--Grayscale-Gray-5, #888);
-
-// /* Body/L (20,20,18)/SB */
-// font-family: Pretendard;
-// font-size: var(--Typo-Size-Body-L, 1.25rem);
-// font-style: normal;
-// font-weight: 600;
-// line-height: var(--Typo-Line-height-Body-L, 2rem); /* 160% */

--- a/src/app/(main)/saved/_components/explore-button.tsx
+++ b/src/app/(main)/saved/_components/explore-button.tsx
@@ -1,15 +1,14 @@
 import ReadingGlasses from "@/assets/icons/reading-glasses.svg";
+import Link from "next/link";
 
-interface ExploreButtonProps {
-  onClick?: () => void;
-}
-
-const ExploreButton = ({ onClick }: ExploreButtonProps) => {
+const ExploreButton = () => {
   return (
-    <button className="button-explore" onClick={onClick}>
-      <ReadingGlasses />
-      브리더 탐색하기
-    </button>
+    <Link href="/explore">
+      <button className="button-explore">
+        <ReadingGlasses />
+        브리더 탐색하기
+      </button>
+    </Link>
   );
 };
 

--- a/src/components/gnb/gnb.tsx
+++ b/src/components/gnb/gnb.tsx
@@ -6,16 +6,24 @@ import NavBar from "./nav-bar";
 import NavButton from "./nav-button";
 import NoticeButton from "./notice-button";
 
-export default function Gnb() {
+interface GnbProps {
+  variant?: "default" | "tertiary";
+}
+
+export default function Gnb({ variant = "default" }: GnbProps) {
   const isMd = useBreakpoint("md");
+  const bgClass = variant === "tertiary" ? "bg-tertiary-500" : "bg-background";
+
   return (
-    <Container className="h-16 flex items-center justify-between">
-      <LogoButton />
-      {isMd && <NavBar />}
-      <div className="flex gap-4 items-center">
-        <NoticeButton />
-        {!isMd && <NavButton />}
-      </div>
-    </Container>
+    <div className={bgClass}>
+      <Container className="h-16 flex items-center justify-between">
+        <LogoButton />
+        {isMd && <NavBar />}
+        <div className="flex gap-4 items-center">
+          <NoticeButton />
+          {!isMd && <NavButton />}
+        </div>
+      </Container>
+    </div>
   );
 }


### PR DESCRIPTION
### 작업 내용

프로필 페이지 UI 구현 및 Gnb 컴포넌트에 variant 시스템을 도입하여 페이지별로 다른 배경색을 적용할 수 있도록 설정했습니다.

###  프로필 페이지 구현
-`/profile` 경로에 대한 기본 페이지 컴포넌트 구현
-`bg-tertiary-500` 배경색으로 회원가입 페이지와 일관된 디자인


###  Gnb 컴포넌트 개선
- `default`와 `tertiary` 두 가지 배경색 옵션 
- `variant` prop으로 동적 배경색 제어
- 경로에 따라 자동으로 적절한 Gnb variant 선택
- **기본 페이지들** (`/explore`, `/saved` 등): `bg-background` (흰색)
- **프로필 페이지** (`/profile`): `bg-tertiary-500` (tertiary 색상)


### 연관 이슈
#17 
