### PR TITLE
feat : 품종 드롭다운 추가 및 padding 수정

### DIFF
--- a/src/app/(main)/profile/_components/parents-info.tsx
+++ b/src/app/(main)/profile/_components/parents-info.tsx
@@ -10,7 +10,12 @@ import PictureRemove from "@/assets/icons/picture-delete.svg";
 import Image from "next/image";
 import { useState, useMemo } from "react";
 import { cn } from "@/lib/utils";
-import BreedsSelectDialogTrigger from "@/app/signup/_components/breeds-select-dialog-trigger";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 interface ParentItem {
   id: string;
@@ -22,7 +27,11 @@ interface ParentItem {
   imageFile?: File;
 }
 
-export default function ParentsInfo() {
+export default function ParentsInfo({
+  selectedBreeds,
+}: {
+  selectedBreeds: string[];
+}) {
   const defaultParentId = useMemo(() => `parent-default-${Date.now()}`, []);
   const [parents, setParents] = useState<ParentItem[]>([
     {
@@ -33,7 +42,6 @@ export default function ParentsInfo() {
       gender: null,
     },
   ]);
-  const [animal] = useState<"dog" | "cat">("dog");
 
   const addParent = () => {
     const newParent: ParentItem = {
@@ -202,27 +210,57 @@ export default function ParentsInfo() {
               onChange={(e) =>
                 updateParent(parent.id, { birthDate: e.target.value })
               }
+              className="px-[var(--space-16)] py-[var(--space-12)]"
             />
-            <BreedsSelectDialogTrigger
-              animal={animal!}
-              onSubmitBreeds={(breeds) =>
-                updateParent(parent.id, { breed: breeds })
-              }
-              asChild
-            >
-              <Button variant="input" className="py-3 px-4 pr-3.5 ">
-                <div className="flex-1 text-left overflow-hidden text-ellipsis whitespace-nowrap">
-                  {parent.breed.length > 0 ? (
-                    <span className="text-[#4F3B2E]">
-                      {parent.breed.join("/")}
-                    </span>
-                  ) : (
-                    <span>품종</span>
-                  )}
-                </div>
-                <Arrow className="size-5 text-[#4F3B2E]" />
-              </Button>
-            </BreedsSelectDialogTrigger>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="input"
+                  size={undefined}
+                  className="!px-[var(--space-16)] !py-[var(--space-12)] w-full"
+                >
+                  <div className="flex-1 text-left overflow-hidden text-ellipsis whitespace-nowrap">
+                    {parent.breed.length > 0 ? (
+                      <span className="text-[#4F3B2E]">
+                        {parent.breed.join("/")}
+                      </span>
+                    ) : (
+                      <span className="text-grayscale-gray5">품종</span>
+                    )}
+                  </div>
+                  <Arrow className="size-5 text-[#4F3B2E]" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                className="w-[var(--radix-dropdown-menu-trigger-width)] bg-white p-1 rounded-lg min-w-[353px]"
+                align="start"
+                side="bottom"
+                sideOffset={4}
+                avoidCollisions={false}
+              >
+                {selectedBreeds.length > 0 ? (
+                  selectedBreeds.map((breed) => (
+                    <DropdownMenuItem
+                      key={breed}
+                      className={cn(
+                        "px-4 py-2 text-body-s font-medium cursor-pointer rounded text-grayscale-gray6 focus:bg-transparent focus:text-grayscale-gray6"
+                      )}
+                      onClick={() => {
+                        updateParent(parent.id, {
+                          breed: parent.breed.includes(breed) ? [] : [breed],
+                        });
+                      }}
+                    >
+                      {breed}
+                    </DropdownMenuItem>
+                  ))
+                ) : (
+                  <div className="px-4 py-2 text-body-s text-grayscale-gray5">
+                    선택된 품종이 없습니다
+                  </div>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
 
             {/* 구분선 (마지막 항목이 아닐 때만) */}
             {index < parents.length - 1 && (

--- a/src/app/(main)/profile/_components/profile-basic-info.tsx
+++ b/src/app/(main)/profile/_components/profile-basic-info.tsx
@@ -11,20 +11,17 @@ import BreedsSelectDialogTrigger from "@/app/signup/_components/breeds-select-di
 import { useState } from "react";
 import LocationSelectDialogTrigger from "@/app/signup/_components/location-select-dialog-trigger";
 import ImageEdit from "@/components/image-edit";
-import ErrorMessage from "@/components/error-message";
 import MinusIcon from "@/assets/icons/minus.svg";
-export default function ProfileBasicInfo() {
-  const messages: Array<{ type: "error"; text: string }> = [
-    { type: "error", text: "지역을 선택해 주세요" },
-    { type: "error", text: "최대 다섯 가지 선택할 수 있어요" },
-    {
-      type: "error",
-      text: "품종을 선택해 주세요",
-    },
-  ];
+export default function ProfileBasicInfo({
+  breeds,
+  setBreeds,
+}: {
+  breeds: string[];
+  setBreeds: (breeds: string[]) => void;
+}) {
   const [animal] = useState<"dog" | "cat">("dog");
-  const [breeds, setBreeds] = useState<string[]>([]);
   const [breederLocation, setBreederLocation] = useState<string | null>(null);
+  const [isCounselMode, setIsCounselMode] = useState(false);
   return (
     <div className="flex flex-col gap-8 items-start w-full">
       <div className="flex flex-col gap-3 items-center w-full">
@@ -41,7 +38,11 @@ export default function ProfileBasicInfo() {
           }}
           asChild
         >
-          <Button variant="input" className="py-3 px-4 pr-3.5">
+          <Button
+            variant="input"
+            size={undefined}
+            className="!px-[var(--space-16)] !py-[var(--space-12)]"
+          >
             {breederLocation ? (
               <span className="text-[#4F3B2E]">{breederLocation}</span>
             ) : (
@@ -62,7 +63,11 @@ export default function ProfileBasicInfo() {
             onSubmitBreeds={setBreeds}
             asChild
           >
-            <Button variant="input" className="py-3 px-4 pr-3.5 ">
+            <Button
+              variant="input"
+              size={undefined}
+              className="!px-[var(--space-16)] !py-[var(--space-12)]"
+            >
               <div className="flex-1 text-left overflow-hidden text-ellipsis whitespace-nowrap">
                 {breeds.length > 0 ? (
                   <span className="text-[#4F3B2E]">{breeds.join("/")}</span>
@@ -93,12 +98,23 @@ export default function ProfileBasicInfo() {
           <p className="leading-body-xs">입양 비용 범위</p>
         </div>
         <div className="flex gap-3 items-center relative w-full flex-nowrap">
-          <PriceInput placeholder="0" className="grow" />
+          <PriceInput
+            placeholder={isCounselMode ? "상담 후 공개" : "0"}
+            className="grow"
+            disabled={isCounselMode}
+          />
           <div className="overflow-hidden relative shrink-0 size-4">
             <MinusIcon className="size-4" />
           </div>
-          <PriceInput placeholder="0" className="grow" />
-          <button className="button-after-counsel  shrink-0 whitespace-nowrap">
+          <PriceInput
+            placeholder={isCounselMode ? "상담 후 공개" : "0"}
+            className="grow"
+            disabled={isCounselMode}
+          />
+          <button
+            onClick={() => setIsCounselMode(!isCounselMode)}
+            className="button-after-counsel shrink-0 whitespace-nowrap"
+          >
             상담 후 공개하기
           </button>
         </div>

--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -1,13 +1,14 @@
 "use client";
 import { Button } from "@/components/ui/button";
-import Container from "@/components/ui/container";
 import { useBreakpoint } from "@/hooks/use-breakpoint";
+import { useState } from "react";
 import ProfileBasicInfo from "./_components/profile-basic-info";
 import ParentsInfo from "./_components/parents-info";
 import BreedingAnimals from "./_components/breeding-animals";
 
 export default function ProfilePage() {
   const isMdUp = useBreakpoint("md");
+  const [breeds, setBreeds] = useState<string[]>([]);
 
   return (
     <div className="min-h-screen flex w-full flex-col md:flex-row">
@@ -17,9 +18,9 @@ export default function ProfilePage() {
       <div className="w-full md:w-1/2 flex flex-col">
         <div className="flex flex-col gap-8 md:gap-20 items-center pb-20 py-14 px-8">
           {/* 프로필 기본 정보 */}
-          <ProfileBasicInfo />
+          <ProfileBasicInfo breeds={breeds} setBreeds={setBreeds} />
           {/* 엄마 아빠 정보 */}
-          <ParentsInfo />
+          <ParentsInfo selectedBreeds={breeds} />
           {/* 분양 중인 아이 */}
           <BreedingAnimals />
           {/* 탈퇴하기 링크 */}

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -151,8 +151,8 @@
   /* Grayscale Colors */
   --color-grayscale-black: oklch(23.5% 0 0);
   --color-grayscale-gray7: oklch(30.5% 0 0);
-  --color-grayscale-gray6: oklch(39.6% 0 0);
-  --color-grayscale-gray5: oklch(54.2% 0 0);
+  --color-grayscale-gray6: #545454;
+  --color-grayscale-gray5: #888;
   --color-grayscale-gray4: oklch(63.5% 0 0);
   --color-grayscale-gray3: oklch(78.5% 0 0);
   --color-grayscale-gray2: oklch(87.6% 0 0);

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -28,7 +28,7 @@ const buttonVariants = cva(
         femaleGender: "hover:bg-[var(--color-gender-female-100)]",
         addParent: "bg-tertiary-700 hover:bg-tertiary-800",
         input:
-          "bg-white text-grayscale-gray4 hover:bg-white/90 justify-between w-full ",
+          "bg-white text-grayscale-gray4 hover:bg-white/90 justify-between w-full text-body-s",
       },
       size: {
         default: "px-2.5 py-1.5 has-[>svg]:px-3",

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -46,7 +46,6 @@ function DropdownMenuContent({
 
           className
         )}
-        style={{ boxShadow: "0 0 13px 0 #0C111D14" }}
         {...props}
       />
     </DropdownMenuPrimitive.Portal>
@@ -76,7 +75,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2.5 py-2 text-body-xs outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 text-grayscale-gray6",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2.5 py-2 text-body-s outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 text-grayscale-gray6",
         className
       )}
       {...props}

--- a/src/components/ui/price-input.tsx
+++ b/src/components/ui/price-input.tsx
@@ -23,7 +23,7 @@ export function PriceInput({
           type="text"
           placeholder={placeholder}
           data-slot="input"
-          className="file:text-foreground placeholder:text-grayscale-gray4 selection:bg-primary selection:text-primary-foreground bg-transparent font-medium text-body-s outline-none file:inline-flex file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 w-full"
+          className="file:text-foreground placeholder:text-grayscale-gray5 selection:bg-primary selection:text-primary-foreground bg-transparent font-medium text-body-s outline-none file:inline-flex file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:text-grayscale-gray4 w-full"
           {...props}
         />
       </div>

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -47,7 +47,7 @@ function Textarea({
         ref={textareaRef}
         data-slot="textarea"
         className={cn(
-          "bg-transparent w-full min-h-[140px] h-auto px-4 pt-3 pb-8 text-body-s font-medium text-grayscale-gray5 placeholder:text-grayscale-gray5 focus:outline-none border-none resize-none overflow-hidden",
+          "bg-transparent w-full min-h-[140px] h-auto px-4 pt-3 pb-8 text-body-s font-medium text-primary-500-basic placeholder:text-grayscale-gray5 focus:outline-none border-none resize-none overflow-hidden",
           className
         )}
         maxLength={maxLength}

--- a/src/styles/button.css
+++ b/src/styles/button.css
@@ -2,12 +2,12 @@
 
 @layer components {
   .button-explore {
-    @apply flex items-center justify-center bg-[var(--color-grayscale-gray1)] text-[var(--color-grayscale-gray6)] gap-[var(--space-4)] rounded-full text-body-s font-medium py-[var(--space-10)] pr-[var(--space-20)] pl-[var(--space-12)];
+    @apply flex items-center justify-center bg-[var(--color-grayscale-gray1)] text-[var(--color-grayscale-gray6)] gap-[var(--space-4)] rounded-full text-body-s font-medium py-[var(--space-10)] pr-[var(--space-20)] pl-[var(--space-12)] cursor-pointer;
   }
   .button-after-counsel {
-    @apply flex items-center justify-center rounded-lg bg-tertiary-700 text-[var(--color-grayscale-gray6)] gap-[var(--space-4)] text-body-s font-semibold pt-[var(--space-12)] pb-[var(--space-12)] pr-[var(--space-16)]  pl-[var(--space-16)];
+    @apply flex items-center justify-center rounded-lg bg-tertiary-700 text-[var(--color-grayscale-gray6)] gap-[var(--space-4)] text-body-s font-semibold pt-[var(--space-12)] pb-[var(--space-12)] pr-[var(--space-16)]  pl-[var(--space-16)] cursor-pointer hover:bg-tertiary-800;
   }
   .button-gender {
-    @apply flex items-center justify-center rounded-lg bg-white text-[var(--color-grayscale-gray4)] gap-[var(--space-4)] text-body-s font-medium py-[var(--space-12)] pr-[var(--space-16)] pl-[var(--space-12)];
+    @apply flex items-center justify-center rounded-lg bg-white text-[var(--color-grayscale-gray4)] gap-[var(--space-4)] text-body-s font-medium py-[var(--space-12)] pr-[var(--space-16)] pl-[var(--space-12)] cursor-pointer;
   }
 }


### PR DESCRIPTION
### 작업 내용

### 품종 드롭다운 메뉴 추가
  - `BreedsSelectDialogTrigger`-> `DropdownMenu`로 변경
  - 상위에서 선택한 품종 목록을 드롭다운으로 표시
  - 선택된 품종이 없을 경우 "선택된 품종이 없습니다" 안내 메시지 표시

###  상담 후 공개 기능 추가
  - 입양 비용 범위 입력 필드에 "상담 후 공개" 모드 추가
  - `isCounselMode` 상태를 통한 모드 전환
  - 상담 모드 활성화 시 입력 필드 비활성화 및 placeholder 변경

### UI 수정
  - 모든 입력 필드에 `px-[var(--space-16)] py-[var(--space-12)]` 패딩 적용
  - placeholder 텍스트 색상 수정
  - 입력값 텍스트 색상 수정

### 연관 이슈
#17 