### PR TITLE
desgin : 토스트 넓이 수정, (데스크톱)수정하기 버튼 위치 수정

### DIFF
--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -64,7 +64,7 @@ export default function ProfilePage() {
         </div>
 
         {/* 수정하기 버튼 */}
-        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 px-8 w-full max-w-[424px] md:bottom-10 md:left-3/4 md:-translate-x-1/2 md:w-[424px]">
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 px-8 w-full max-w-[424px] md:bottom-10 md:left-[calc(50%+20%)] md:-translate-x-1/2 md:w-[424px] md:px-0">
           <Button
             className="bg-status-disabled flex h-12 items-center justify-center min-w-20 px-4 py-3 rounded-lg w-full md:w-[424px]"
             onClick={handleEdit}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -14,7 +14,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed z-[100] flex max-h-screen flex-col-reverse p-0 bottom-[calc(1.5rem+3rem+0.75rem)] left-1/2 -translate-x-1/2  md:bottom-[calc(2.5rem+3rem+0.75rem)] md:left-3/4 md:-translate-x-1/2 md:w-[424px]",
+      "fixed z-[100] flex max-h-screen flex-col-reverse p-0 bottom-[calc(1.5rem+3rem+0.75rem)] left-1/2 -translate-x-1/2  md:bottom-[calc(2.5rem+3rem+0.75rem)] md:left-[calc(50%+20%)] md:-translate-x-1/2",
       className
     )}
     {...props}


### PR DESCRIPTION
### 작업 내용

### 수정하기 버튼 위치 조정

  - 데스크톱에서 버튼 위치를 `md:left-3/4`에서 `md:left-[calc(50%+20%)]`로 조정
  - 상위 div의 `px-8` 패딩으로 인한 정렬 문제 해결을 위해 `md:px-0` 추가

### 토스트 위치 조정
  - `md:left-3/4`에서 `md:left-[calc(50%+20%)]`로 변경
 
### 연관 이슈

관련이슈 번호를 close해주세요.
#17 
