### PR TITLE
feat : gnb 하위 메뉴 구현 및 라우팅 추가

### DIFF
--- a/src/app/(main)/explore/_components/site-breeder-list.tsx
+++ b/src/app/(main)/explore/_components/site-breeder-list.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import AdoptionStatusBadge from "@/components/adoption-status-badge";
 import BreederDescription from "@/components/breeder-list/breader-description";
 import BreederLikeButton from "@/components/breeder-list/breader-like-button";
@@ -76,41 +77,47 @@ const breederListInfo: {
 export default function SiteBreederList() {
   return (
     <BreederList>
-      {breederListInfo.map((breeder, index) => (
-        <Breeder key={index}>
-          <BreederProfile>
-            <BreederHeader>
-              <BreederAvatar src={breeder.avatar} />
-              <div className="flex items-center gap-2">
-                <BreederName>{breeder.name}</BreederName>
-                <LevelBadge level={breeder.level} />
+      {breederListInfo.map((breeder) => (
+        <Link
+          key={breeder.id}
+          href={`/explore/breeder/${breeder.id}`}
+          className="block"
+        >
+          <Breeder>
+            <BreederProfile>
+              <BreederHeader>
+                <BreederAvatar src={breeder.avatar} />
+                <div className="flex items-center gap-2">
+                  <BreederName>{breeder.name}</BreederName>
+                  <LevelBadge level={breeder.level} />
+                </div>
+              </BreederHeader>
+              <BreederContent>
+                <BreederDescription>
+                  <BreederLocation>{breeder.location}</BreederLocation>
+                  <GrayDot className="block sm:hidden lg:block align-middle" />
+                  <BreederPrice>{breeder.price}</BreederPrice>
+                </BreederDescription>
+                <BreederTags>
+                  {breeder.tags.map((tag, idx) => (
+                    <Button variant="secondary" key={idx}>
+                      {tag}
+                    </Button>
+                  ))}
+                </BreederTags>
+              </BreederContent>
+            </BreederProfile>
+            <div className="relative">
+              <BreederImage src={breeder.image} />
+              <div className="absolute top-0 right-0 p-3">
+                <BreederLikeButton breederId={breeder.id} />
               </div>
-            </BreederHeader>
-            <BreederContent>
-              <BreederDescription>
-                <BreederLocation>{breeder.location}</BreederLocation>
-                <GrayDot className="block sm:hidden lg:block align-middle" />
-                <BreederPrice>{breeder.price}</BreederPrice>
-              </BreederDescription>
-              <BreederTags>
-                {breeder.tags.map((tag, idx) => (
-                  <Button variant="secondary" key={idx}>
-                    {tag}
-                  </Button>
-                ))}
-              </BreederTags>
-            </BreederContent>
-          </BreederProfile>
-          <div className="relative">
-            <BreederImage src="/main-img-sample.png" />
-            <div className="absolute top-0 right-0 p-3">
-              <BreederLikeButton breederId={breeder.id} />
+              <div className="absolute bottom-0 right-0 p-3">
+                <AdoptionStatusBadge status={breeder.status} />
+              </div>
             </div>
-            <div className="absolute bottom-0 right-0 p-3">
-              <AdoptionStatusBadge status={breeder.status} />
-            </div>
-          </div>
-        </Breeder>
+          </Breeder>
+        </Link>
       ))}
     </BreederList>
   );

--- a/src/app/(main)/explore/breeder/[id]/_components/breeder-profile.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/breeder-profile.tsx
@@ -1,5 +1,10 @@
+"use client";
+
 import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
 import LevelBadge from "../../../../../../components/level-badge";
+import { useCounselFormStore } from "@/stores/counsel-form-store";
 
 export default function BreederProfile({
   data: { avatarUrl, nickname, level, location, priceRange, breeds },
@@ -13,40 +18,58 @@ export default function BreederProfile({
     breeds: string[];
   };
 }) {
+  const router = useRouter();
+  const { clearCounselFormData } = useCounselFormStore();
+
+  const handleCounselClick = () => {
+    clearCounselFormData();
+    router.push("/counselform");
+  };
+
   return (
-    <div className="flex gap-4 lg:w-51 lg:flex-col lg:gap-8">
-      <div className="w-[8.25rem] h-[8.25rem] md:w-[10rem] md:h-[10rem] lg:w-[12.75rem] lg:h-[12.75rem] rounded-lg overflow-hidden shrink-0">
-        <Image
-          src={avatarUrl}
-          alt={nickname}
-          width={204}
-          height={204}
-          className="object-cover w-full h-full rounded-[0.452rem]"
-        />
-      </div>
-      <div className="flex-1 space-y-4 flex flex-col md:justify-between">
-        <div className="flex items-center flex-wrap gap-2">
-          <span className="text-heading-3 text-primary font-semibold">
-            {nickname}
-          </span>
-          <LevelBadge level={level} />
+    <div className="flex flex-col gap-4 lg:w-51">
+      <div className="flex gap-4 lg:flex-col lg:gap-8">
+        <div className="w-[8.25rem] h-[8.25rem] md:w-[10rem] md:h-[10rem] lg:w-[12.75rem] lg:h-[12.75rem] rounded-lg overflow-hidden shrink-0">
+          <Image
+            src={avatarUrl}
+            alt={nickname}
+            width={204}
+            height={204}
+            className="object-cover w-full h-full rounded-[0.452rem]"
+          />
         </div>
-        <div className="space-y-3">
-          <div className="text-body-s mb-2 text-grayscale-gray5">
-            <div>{location}</div>
-            <div>{priceRange}</div>
+        <div className="flex-1 space-y-4 flex flex-col md:justify-between">
+          <div className="flex items-center flex-wrap gap-2">
+            <span className="text-heading-3 text-primary font-semibold">
+              {nickname}
+            </span>
+            <LevelBadge level={level} />
           </div>
-          <div className="flex flex-wrap gap-2">
-            {breeds.map((breed) => (
-              <div
-                key={breed}
-                className="bg-tertiary-500 py-1.5 px-2.5 rounded-[--spacing(1)] text-medium text-body-xs text-primary"
-              >
-                {breed}
-              </div>
-            ))}
+          <div className="space-y-3">
+            <div className="text-body-s mb-2 text-grayscale-gray5">
+              <div>{location}</div>
+              <div>{priceRange}</div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {breeds.map((breed) => (
+                <div
+                  key={breed}
+                  className="bg-tertiary-500 py-1.5 px-2.5 rounded-[--spacing(1)] text-medium text-body-xs text-primary"
+                >
+                  {breed}
+                </div>
+              ))}
+            </div>
           </div>
         </div>
+        <Button
+          variant="counsel"
+          className="w-full h-12 rounded-lg text-body-s font-semibold text-primary-500"
+          type="button"
+          onClick={handleCounselClick}
+        >
+          상담 신청하기
+        </Button>
       </div>
     </div>
   );

--- a/src/components/gnb/nav-bar.tsx
+++ b/src/components/gnb/nav-bar.tsx
@@ -2,43 +2,28 @@
 
 import Link from "next/link";
 import { MouseEvent } from "react";
-import Letter from "@/assets/icons/letter";
-import LetterFill from "@/assets/icons/letter-fill";
-import Profile from "@/assets/icons/profile";
-import ProfileFill from "@/assets/icons/profile-fill";
-import Search from "@/assets/icons/search";
-import SearchFill from "@/assets/icons/search-fill";
 import { useSegment } from "@/hooks/use-segment";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { Button } from "../ui/button";
 import { useNavigationGuardContext } from "@/contexts/navigation-guard-context";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
+import { NAV_ITEMS, NAV_ITEMS_BREEDER } from "./nav-items";
 
-const navItems = [
-  {
-    name: "탐색",
-    href: "/explore",
-    icon: Search,
-    iconFill: SearchFill,
-  },
-  {
-    name: "신청",
-    href: "/application",
-    icon: Letter,
-    iconFill: LetterFill,
-  },
-  {
-    name: "마이",
-    href: "/profile",
-    icon: Profile,
-    iconFill: ProfileFill,
-  },
-];
+interface NavBarProps {
+  navVariant?: "default" | "breeder";
+}
 
-export default function NavBar() {
+export default function NavBar({ navVariant = "default" }: NavBarProps) {
   const currNav = useSegment(0);
   const pathname = usePathname();
   const guardContext = useNavigationGuardContext();
+  const navConfig = navVariant === "breeder" ? NAV_ITEMS_BREEDER : NAV_ITEMS;
 
   const handleLinkClick = (e: MouseEvent<HTMLAnchorElement>, href: string) => {
     // Context가 없거나 같은 페이지면 기본 동작 허용
@@ -53,32 +38,100 @@ export default function NavBar() {
 
   return (
     <div className="flex">
-      {navItems.map((item) => {
+      {navConfig.map((item) => {
         const active = currNav === item.href.slice(1);
         const Icon = active ? item.iconFill : item.icon;
-        return (
-          <Link
-            href={item.href}
-            key={item.name}
-            onClick={(e) => handleLinkClick(e, item.href)}
-          >
-            <Button
+        const hasChildren = Boolean(item.children?.length);
+
+        if (!hasChildren) {
+          return (
+            <Link
+              href={item.href}
               key={item.name}
-              variant="ghost"
-              className={cn(
-                " h-auto gap-1.5 has-[>svg]:px-5 text-body-s text-grayscale-gray6 hover:text-primary! "
-              )}
+              onClick={(e) => handleLinkClick(e, item.href)}
             >
-              <Icon className="size-5" />
-              <span
-                className={cn({
-                  "text-primary font-semibold": active,
-                })}
+              <Button
+                key={item.name}
+                variant="ghost"
+                className={cn(
+                  "h-auto gap-1.5 has-[>svg]:px-5 text-body-s text-grayscale-gray6 hover:text-primary!"
+                )}
               >
-                {item.name}
-              </span>
-            </Button>
-          </Link>
+                <Icon className="size-5" />
+                <span
+                  className={cn({
+                    "text-primary font-semibold": active,
+                  })}
+                >
+                  {item.name}
+                </span>
+              </Button>
+            </Link>
+          );
+        }
+
+        return (
+          <DropdownMenu key={item.name}>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                className={cn(
+                  "h-auto gap-1.5 has-[>svg]:px-5 text-body-s text-grayscale-gray6",
+                  active && "text-primary"
+                )}
+              >
+                <Icon className="size-5" />
+                <span
+                  className={cn({
+                    "text-primary font-semibold": active,
+                  })}
+                >
+                  {item.name}
+                </span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="start"
+              sideOffset={12}
+              className="border border-grayscale-gray2/50 rounded-lg p-1 shadow-[0px_8px_24px_rgba(12,17,29,0.12)] "
+            >
+              {item.children?.map((child) => {
+                const ChildIcon = child.icon;
+                const isMuted = child.variant === "muted";
+                const isDisabled = child.variant === "disabled";
+                return (
+                  <DropdownMenuItem
+                    key={child.name}
+                    asChild
+                    className={cn(
+                      "px-4 py-2 text-body-s text-grayscale-gray7 gap-3 cursor-pointer w-[9.5625rem]",
+                      isMuted && "text-grayscale-gray5 font-medium",
+                      isDisabled &&
+                        "text-[#e1e1e1] font-medium cursor-default pointer-events-none"
+                    )}
+                  >
+                    <Link
+                      href={child.href}
+                      onClick={(e) => handleLinkClick(e, child.href)}
+                      aria-disabled={isDisabled}
+                    >
+                      <div
+                        className={cn(
+                          "flex items-center gap-3",
+                          !ChildIcon && "gap-0"
+                        )}
+                      >
+                        {ChildIcon && (
+                          <ChildIcon className="size-5 text-grayscale-gray5" />
+                        )}
+                        <span>{child.name}</span>
+                      </div>
+                    </Link>
+                  </DropdownMenuItem>
+                );
+              })}
+            </DropdownMenuContent>
+          </DropdownMenu>
         );
       })}
     </div>

--- a/src/components/gnb/nav-items.ts
+++ b/src/components/gnb/nav-items.ts
@@ -1,0 +1,88 @@
+import type { ComponentType, SVGProps } from "react";
+
+import Search from "@/assets/icons/search";
+import SearchFill from "@/assets/icons/search-fill";
+import Letter from "@/assets/icons/letter";
+import LetterFill from "@/assets/icons/letter-fill";
+import Profile from "@/assets/icons/profile";
+import ProfileFill from "@/assets/icons/profile-fill";
+import Cat from "@/assets/icons/cat";
+import Dog from "@/assets/icons/dog";
+
+export type NavChildVariant = "default" | "muted" | "disabled";
+
+export interface NavChildItem {
+  name: string;
+  href: string;
+  icon?: ComponentType<SVGProps<SVGSVGElement>>;
+  variant?: NavChildVariant;
+}
+
+export interface NavItem {
+  name: string;
+  href: string;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  iconFill: ComponentType<SVGProps<SVGSVGElement>>;
+  children?: NavChildItem[];
+}
+
+export const NAV_ITEMS: NavItem[] = [
+  {
+    name: "탐색",
+    href: "/explore",
+    icon: Search,
+    iconFill: SearchFill,
+    children: [
+      { name: "고양이", href: "/explore/cat", icon: Cat },
+      { name: "강아지", href: "/explore/dog", icon: Dog },
+    ],
+  },
+  {
+    name: "신청",
+    href: "/application",
+    icon: Letter,
+    iconFill: LetterFill,
+  },
+  {
+    name: "마이",
+    href: "/profile",
+    icon: Profile,
+    iconFill: ProfileFill,
+    children: [
+      { name: "내 후기", href: "/myapplication" },
+      { name: "찜한 브리더", href: "/saved" },
+      { name: "공지사항", href: "/notice" },
+      { name: "설정", href: "/profile/settings" },
+      { name: "로그아웃", href: "/logout", variant: "muted" },
+    ],
+  },
+];
+
+export const NAV_ITEMS_BREEDER: NavItem[] = [
+  {
+    name: "탐색",
+    href: "/explore",
+    icon: Search,
+    iconFill: SearchFill,
+  },
+  {
+    name: "신청",
+    href: "/application",
+    icon: Letter,
+    iconFill: LetterFill,
+  },
+  {
+    name: "마이",
+    href: "/profile",
+    icon: Profile,
+    iconFill: ProfileFill,
+    children: [
+      { name: "내 프로필", href: "/profile", variant: "disabled" },
+      { name: "입점 서류 수정", href: "/profile/documents" },
+      { name: "찜한 브리더", href: "/saved" },
+      { name: "공지사항", href: "/notice" },
+      { name: "설정", href: "/profile/settings" },
+      { name: "로그아웃", href: "/logout", variant: "muted" },
+    ],
+  },
+];

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -30,6 +30,7 @@ const buttonVariants = cva(
         addParent: "bg-tertiary-700 hover:bg-tertiary-800",
         input:
           "bg-white text-grayscale-gray4 hover:bg-white/90 justify-between w-full text-body-s",
+        counsel: "bg-secondary-500 hover:bg-secondary-600",
       },
       size: {
         default: "px-2.5 py-1.5 has-[>svg]:px-3",


### PR DESCRIPTION
### 작업 내용

## GNB 하위 메뉴 구현
- GNB 하위 메뉴 추가 및 일반/브리더 UI 분기

## 상담 신청하기 버튼 추가
- 브리더 상세 상단에 상담 신청 버튼을 추가해 폼 데이터를 초기화한 뒤 `/counselform`으로 임시 이동(추후 아이디 기반 이동으로 변경 예정)

### 연관 이슈
#47 
