### PR TITLE
design : animal-category-cards 배경색 변경

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -128,6 +128,7 @@
   --color-secondary-100: oklch(91.7% 0.071 259.9);
   --color-secondary-300: oklch(87.1% 0.076 251.1);
   --color-secondary-500: #a0c8f4;
+  --color-secondary-500-basic: #a0c8f4;
   --color-secondary-600: #77b2f3;
   --color-secondary-700: oklch(68.8% 0.122 231.9);
   --color-secondary-800: oklch(62.4% 0.138 231.4);

--- a/src/components/animal-category-cards.tsx
+++ b/src/components/animal-category-cards.tsx
@@ -18,13 +18,13 @@ const animalInfo: AnimalCategoryCard[] = [
   {
     name: "cat",
     label: "고양이",
-    className: "bg-primary hover:bg-primary-600 text-tertiary-500",
+    className: "bg-primary-500 hover:bg-primary-600 text-tertiary-500",
     src: "/images/cat.png",
   },
   {
     name: "dog",
     label: "강아지",
-    className: "bg-secondary hover:bg-secondary-600 text-primary!",
+    className: "bg-secondary-500-basic hover:bg-secondary-600 text-primary-500",
     src: "/images/dog.png",
   },
 ];


### PR DESCRIPTION
### 작업 내용

## animal-category-cards 배경색 변경
- 고양이 카드 primary -> primary-500
- 강아지 카드 secondary-500 -> secondary-500-basic
## 디자인 토큰 추가
`--color-secondary-500-basic: #a0c8f4` 추가

### 연관 이슈

관련이슈 번호를 close해주세요.
예시 close #1
