### PR TITLE
feat : 브리더 프로필 케이스 분리

### DIFF
--- a/src/app/(main)/explore/_components/site-breeder-list.tsx
+++ b/src/app/(main)/explore/_components/site-breeder-list.tsx
@@ -16,68 +16,12 @@ import BreederTags from "@/components/breeder-list/breeder-tags";
 import LevelBadge from "@/components/level-badge";
 import { Button } from "@/components/ui/button";
 import GrayDot from "@/assets/icons/gray-dot.svg";
-
-const breederListInfo: {
-  id: string;
-  avatar: string;
-  name: string;
-  level: "elite" | "new";
-  location: string;
-  price: string;
-  tags: string[];
-  image: string;
-  status: "available" | "reserved" | "completed";
-}[] = [
-  {
-    id: "1",
-    avatar: "/avatar-sample.png",
-    name: "범과같이",
-    level: "elite",
-    location: "경기도 용인시",
-    price: "500,000 - 1,000,000원",
-    tags: ["시베리안(트래디셔널, 네바마스커레이드)", "브리티쉬 롱헤어"],
-    image: "/main-img-sample.png",
-    status: "available",
-  },
-  {
-    id: "2",
-    avatar: "/avatar-sample.png",
-    name: "범과같이",
-    level: "elite",
-    location: "경기도 용인시",
-    price: "500,000 - 1,000,000원",
-    tags: ["시베리안(트래디셔널, 네바마스커레이드)", "브리티쉬 롱헤어"],
-    image: "/main-img-sample.png",
-    status: "reserved",
-  },
-  {
-    id: "3",
-    avatar: "/avatar-sample.png",
-    name: "범과같이",
-    level: "elite",
-    location: "경기도 용인시",
-    price: "500,000 - 1,000,000원",
-    tags: ["시베리안(트래디셔널, 네바마스커레이드)", "브리티쉬 롱헤어"],
-    image: "/main-img-sample.png",
-    status: "completed",
-  },
-  {
-    id: "4",
-    avatar: "/avatar-sample.png",
-    name: "범과같이",
-    level: "elite",
-    location: "경기도 용인시",
-    price: "500,000 - 1,000,000원",
-    tags: ["시베리안(트래디셔널, 네바마스커레이드)", "브리티쉬 롱헤어"],
-    image: "/main-img-sample.png",
-    status: "available",
-  },
-];
+import { BREEDER_LIST_MOCK } from "@/app/(main)/explore/_mocks/explore-mock-data";
 
 export default function SiteBreederList() {
   return (
     <BreederList>
-      {breederListInfo.map((breeder) => (
+      {BREEDER_LIST_MOCK.map((breeder) => (
         <Link
           key={breeder.id}
           href={`/explore/breeder/${breeder.id}`}
@@ -86,7 +30,7 @@ export default function SiteBreederList() {
           <Breeder>
             <BreederProfile>
               <BreederHeader>
-                <BreederAvatar src={breeder.avatar} />
+                <BreederAvatar src={breeder.avatar} animal={breeder.animal} />
                 <div className="flex items-center gap-2">
                   <BreederName>{breeder.name}</BreederName>
                   <LevelBadge level={breeder.level} />

--- a/src/app/(main)/explore/_mocks/explore-mock-data.ts
+++ b/src/app/(main)/explore/_mocks/explore-mock-data.ts
@@ -1,0 +1,177 @@
+import type { Animal } from "@/stores/signup-form-store";
+
+export const BREEDER_LIST_MOCK = [
+  {
+    id: "1",
+    avatar: "",
+    name: "범과같이",
+    level: "elite",
+    location: "경기도 용인시",
+    price: "500,000 - 1,000,000원",
+    tags: ["시베리안(트래디셔널, 네바마스커레이드)", "브리티쉬 롱헤어"],
+    image: "/main-img-sample.png",
+    status: "available",
+    animal: "cat",
+  },
+  {
+    id: "2",
+    avatar: "",
+    name: "범과같이",
+    level: "elite",
+    location: "경기도 용인시",
+    price: "500,000 - 1,000,000원",
+    tags: ["시베리안(트래디셔널, 네바마스커레이드)", "브리티쉬 롱헤어"],
+    image: "/main-img-sample.png",
+    status: "reserved",
+    animal: "dog",
+  },
+  {
+    id: "3",
+    avatar: "",
+    name: "범과같이",
+    level: "elite",
+    location: "경기도 용인시",
+    price: "500,000 - 1,000,000원",
+    tags: ["시베리안(트래디셔널, 네바마스커레이드)", "브리티쉬 롱헤어"],
+    image: "/main-img-sample.png",
+    status: "completed",
+    animal: "cat",
+  },
+  {
+    id: "4",
+    avatar: "",
+    name: "범과같이",
+    level: "elite",
+    location: "경기도 용인시",
+    price: "500,000 - 1,000,000원",
+    tags: ["시베리안(트래디셔널, 네바마스커레이드)", "브리티쉬 롱헤어"],
+    image: "/main-img-sample.png",
+    status: "available",
+    animal: "dog",
+  },
+] satisfies {
+  id: string;
+  avatar: string;
+  name: string;
+  level: "elite" | "new";
+  location: string;
+  price: string;
+  tags: string[];
+  image: string;
+  status: "available" | "reserved" | "completed";
+  animal: Animal;
+}[];
+
+export const BREEDER_DETAIL_MOCK = {
+  nickname: "범과 같이",
+  profile: {
+    avatarUrl: "",
+    nickname: "범과 같이",
+    level: "elite",
+    location: "경기도 용인시",
+    priceRange: "500,000 - 1,000,000원",
+    breeds: ["메인쿤", "러시안 블루", "샴"],
+    animal: "cat" as Animal,
+  },
+  envPhotos: ["/login-image.png", "/main-img-sample.png"],
+  description:
+    "이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.",
+  breedingAnimals: [
+    {
+      id: "1",
+      avatarUrl: "/animal-sample.png",
+      name: "루시",
+      sex: "male",
+      birth: "2020-01-01",
+      price: "500,000원",
+      breed: "메인쿤",
+    },
+    {
+      id: "2",
+      avatarUrl: "/animal-sample.png",
+      name: "코코",
+      sex: "female",
+      birth: "2021-01-01",
+      price: "600,000원",
+      breed: "러시안 블루",
+    },
+  ],
+  parents: [
+    {
+      id: "1",
+      avatarUrl: "/animal-sample.png",
+      name: "루시",
+      sex: "male",
+      birth: "2020-01-01",
+      price: "500,000원",
+      breed: "메인쿤",
+    },
+    {
+      id: "2",
+      avatarUrl: "/animal-sample.png",
+      name: "코코",
+      sex: "female",
+      birth: "2021-01-01",
+      price: "600,000원",
+      breed: "러시안 블루",
+    },
+  ],
+  reviews: [
+    {
+      id: "1",
+      nickname: "냥집사",
+      date: "2023-10-01",
+      content: "정말 좋은 브리더님이세요!",
+    },
+    {
+      id: "2",
+      nickname: "펫러버",
+      date: "2023-09-15",
+      content:
+        "아이들이 건강하게 잘 자라고 있어요.분양 과정이 매우 친절했습니다.분양 과정이 매우 친절했습니다.분양 과정이 매우 친절했습니다.분양 과정이 매우 친절했습니다.분양 과정이 매우 친절했습니다.",
+    },
+    {
+      id: "3",
+      nickname: "고양이매니아",
+      date: "2023-08-20",
+      content: "분양 과정이 매우 친절했습니다.",
+    },
+  ],
+} satisfies {
+  nickname: string;
+  profile: {
+    avatarUrl: string;
+    nickname: string;
+    level: "elite" | "new";
+    location: string;
+    priceRange: string;
+    breeds: string[];
+    animal: Animal;
+  };
+  envPhotos: string[];
+  description: string;
+  breedingAnimals: {
+    id: string;
+    avatarUrl: string;
+    name: string;
+    sex: "male" | "female";
+    birth: string;
+    price: string;
+    breed: string;
+  }[];
+  parents: {
+    id: string;
+    avatarUrl: string;
+    name: string;
+    sex: "male" | "female";
+    birth: string;
+    price: string;
+    breed: string;
+  }[];
+  reviews: {
+    id: string;
+    nickname: string;
+    date: string;
+    content: string;
+  }[];
+};

--- a/src/app/(main)/explore/breeder/[id]/_components/breeder-profile.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/breeder-profile.tsx
@@ -6,9 +6,12 @@ import { Button } from "@/components/ui/button";
 import LevelBadge from "../../../../../../components/level-badge";
 import { useCounselFormStore } from "@/stores/counsel-form-store";
 import { useBreakpoint } from "@/hooks/use-breakpoint";
+import Cat from "@/assets/icons/cat";
+import Dog from "@/assets/icons/dog";
+import type { Animal } from "@/stores/signup-form-store";
 
 export default function BreederProfile({
-  data: { avatarUrl, nickname, level, location, priceRange, breeds },
+  data: { avatarUrl, nickname, level, location, priceRange, breeds, animal },
 }: {
   data: {
     avatarUrl: string;
@@ -17,6 +20,7 @@ export default function BreederProfile({
     location: string;
     priceRange: string;
     breeds: string[];
+    animal: Animal;
   };
 }) {
   const router = useRouter();
@@ -28,17 +32,23 @@ export default function BreederProfile({
     router.push("/counselform");
   };
 
+  const IconComponent = animal === "cat" ? Cat : Dog;
+
   return (
     <div className="flex flex-col gap-4 lg:w-51">
       <div className="flex gap-4 lg:flex-col lg:gap-8">
-        <div className="w-[8.25rem] h-[8.25rem] md:w-[10rem] md:h-[10rem] lg:w-[12.75rem] lg:h-[12.75rem] rounded-lg overflow-hidden shrink-0">
-          <Image
-            src={avatarUrl}
-            alt={nickname}
-            width={204}
-            height={204}
-            className="object-cover w-full h-full rounded-[0.452rem]"
-          />
+        <div className="w-[8.25rem] h-[8.25rem] md:w-[10rem] md:h-[10rem] lg:w-[12.75rem] lg:h-[12.75rem] rounded-lg overflow-hidden shrink-0 bg-grayscale-gray1 flex items-center justify-center">
+          {avatarUrl ? (
+            <Image
+              src={avatarUrl}
+              alt={nickname}
+              width={204}
+              height={204}
+              className="object-cover w-full h-full rounded-[0.452rem]"
+            />
+          ) : (
+            <IconComponent className="w-[9.5625rem] h-[9.5625rem] text-grayscale-gray5" />
+          )}
         </div>
         <div className="flex-1 space-y-4 flex flex-col md:justify-between">
           <div className="flex items-center flex-wrap gap-2">

--- a/src/app/(main)/explore/breeder/[id]/page.tsx
+++ b/src/app/(main)/explore/breeder/[id]/page.tsx
@@ -12,9 +12,10 @@ import { Button } from "@/components/ui/button";
 import { useRouter } from "next/navigation";
 import { useCounselFormStore } from "@/stores/counsel-form-store";
 import { useBreakpoint } from "@/hooks/use-breakpoint";
+import { BREEDER_DETAIL_MOCK } from "@/app/(main)/explore/_mocks/explore-mock-data";
 
 export default function Page() {
-  const breederNickname = "범과 같이";
+  const breederNickname = BREEDER_DETAIL_MOCK.nickname;
   const router = useRouter();
   const { clearCounselFormData } = useCounselFormStore();
   const isLg = useBreakpoint("lg");
@@ -29,97 +30,20 @@ export default function Page() {
       <Header breederNickname={breederNickname} />
       <div className="pt-4 lg:flex lg:gap-24.5 space-y-10 md:space-y-15 pb-10 md:pb-15 lg:lg-80">
         <div>
-          <BreederProfile
-            data={{
-              avatarUrl: "/avatar-sample.png",
-              nickname: "범과 같이",
-              level: "elite",
-              location: "경기도 용인시",
-              priceRange: "500,000 - 1,000,000원",
-              breeds: ["메인쿤", "러시안 블루", "샴"],
-            }}
-          />
+          <BreederProfile data={BREEDER_DETAIL_MOCK.profile} />
         </div>
         <div className="space-y-12 mt-10 md:mt-0">
-          <EnvPhotos photos={["/login-image.png", "/main-img-sample.png"]} />
+          <EnvPhotos photos={BREEDER_DETAIL_MOCK.envPhotos} />
           <Separator className="my-12" />
 
-          <BreederDescription
-            data={
-              "이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다.이곳은 브리더에 대한 설명입니다."
-            }
-          />
+          <BreederDescription data={BREEDER_DETAIL_MOCK.description} />
           <Separator className="my-12" />
-          <BreedingAnimals
-            data={[
-              {
-                id: "1",
-                avatarUrl: "/animal-sample.png",
-                name: "루시",
-                sex: "male",
-                birth: "2020-01-01",
-                price: "500,000원",
-                breed: "메인쿤",
-              },
-              {
-                id: "2",
-                avatarUrl: "/animal-sample.png",
-                name: "코코",
-                sex: "female",
-                birth: "2021-01-01",
-                price: "600,000원",
-                breed: "러시안 블루",
-              },
-            ]}
-          />
+          <BreedingAnimals data={BREEDER_DETAIL_MOCK.breedingAnimals} />
           <Separator className="my-12" />
-          <Parents
-            data={[
-              {
-                id: "1",
-                avatarUrl: "/animal-sample.png",
-                name: "루시",
-                sex: "male",
-                birth: "2020-01-01",
-                price: "500,000원",
-                breed: "메인쿤",
-              },
-              {
-                id: "2",
-                avatarUrl: "/animal-sample.png",
-                name: "코코",
-                sex: "female",
-                birth: "2021-01-01",
-                price: "600,000원",
-                breed: "러시안 블루",
-              },
-            ]}
-          />
+          <Parents data={BREEDER_DETAIL_MOCK.parents} />
 
           <Separator className="my-12" />
-          <Reviews
-            data={[
-              {
-                id: "1",
-                nickname: "냥집사",
-                date: "2023-10-01",
-                content: "정말 좋은 브리더님이세요!",
-              },
-              {
-                id: "2",
-                nickname: "펫러버",
-                date: "2023-09-15",
-                content:
-                  "아이들이 건강하게 잘 자라고 있어요.분양 과정이 매우 친절했습니다.분양 과정이 매우 친절했습니다.분양 과정이 매우 친절했습니다.분양 과정이 매우 친절했습니다.분양 과정이 매우 친절했습니다.",
-              },
-              {
-                id: "3",
-                nickname: "고양이매니아",
-                date: "2023-08-20",
-                content: "분양 과정이 매우 친절했습니다.",
-              },
-            ]}
-          />
+          <Reviews data={BREEDER_DETAIL_MOCK.reviews} />
         </div>
       </div>
       {!isLg && (

--- a/src/app/(main)/myapplication/_mocks/my-review-mock-data.ts
+++ b/src/app/(main)/myapplication/_mocks/my-review-mock-data.ts
@@ -6,7 +6,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "냥 1번째",
     breederLevel: "elite",
     applicationDate: "2024. 01. 15.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "cat",
     reviewType: "입양 후기",
     reviewContent:
@@ -18,7 +18,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "멍 1번째",
     breederLevel: "new",
     applicationDate: "2024. 01. 18.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "dog",
     reviewType: "상담 후기",
     reviewContent:
@@ -30,7 +30,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "냥 2번째",
     breederLevel: "elite",
     applicationDate: "2024. 02. 05.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "cat",
     reviewType: "입양 후기",
     reviewContent:
@@ -42,7 +42,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "멍 2번째",
     breederLevel: "new",
     applicationDate: "2024. 02. 10.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "dog",
     reviewType: "상담 후기",
     reviewContent:
@@ -54,7 +54,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "냥 3번째",
     breederLevel: "elite",
     applicationDate: "2024. 02. 20.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "cat",
     reviewType: "입양 후기",
     reviewContent:
@@ -66,7 +66,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "멍 3번째",
     breederLevel: "new",
     applicationDate: "2024. 03. 05.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "dog",
     reviewType: "상담 후기",
     reviewContent:
@@ -78,7 +78,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "냥 4번째",
     breederLevel: "elite",
     applicationDate: "2024. 03. 12.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "cat",
     reviewType: "입양 후기",
     reviewContent:
@@ -90,7 +90,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "멍 4번째",
     breederLevel: "new",
     applicationDate: "2024. 03. 18.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "dog",
     reviewType: "상담 후기",
     reviewContent:
@@ -102,7 +102,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "냥 5번째",
     breederLevel: "elite",
     applicationDate: "2024. 04. 01.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "cat",
     reviewType: "입양 후기",
     reviewContent:
@@ -114,7 +114,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "멍 5번째",
     breederLevel: "new",
     applicationDate: "2024. 04. 08.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "dog",
     reviewType: "상담 후기",
     reviewContent:
@@ -126,7 +126,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "냥 6번째",
     breederLevel: "elite",
     applicationDate: "2024. 04. 15.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "cat",
     reviewType: "입양 후기",
     reviewContent:
@@ -138,7 +138,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "멍 6번째",
     breederLevel: "new",
     applicationDate: "2024. 04. 20.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "dog",
     reviewType: "상담 후기",
     reviewContent:
@@ -150,7 +150,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "냥 7번째",
     breederLevel: "elite",
     applicationDate: "2024. 05. 03.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "cat",
     reviewType: "입양 후기",
     reviewContent:
@@ -162,7 +162,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "멍 7번째",
     breederLevel: "new",
     applicationDate: "2024. 05. 10.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "dog",
     reviewType: "상담 후기",
     reviewContent:
@@ -174,7 +174,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "냥 8번째",
     breederLevel: "elite",
     applicationDate: "2024. 05. 18.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "cat",
     reviewType: "입양 후기",
     reviewContent:
@@ -186,7 +186,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "멍 8번째",
     breederLevel: "new",
     applicationDate: "2024. 05. 22.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "dog",
     reviewType: "상담 후기",
     reviewContent:
@@ -198,7 +198,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "냥 9번째",
     breederLevel: "elite",
     applicationDate: "2024. 06. 01.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "cat",
     reviewType: "입양 후기",
     reviewContent:
@@ -210,7 +210,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "멍 9번째",
     breederLevel: "new",
     applicationDate: "2024. 06. 08.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "dog",
     reviewType: "상담 후기",
     reviewContent:
@@ -222,7 +222,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "냥 10번째",
     breederLevel: "elite",
     applicationDate: "2024. 06. 15.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "cat",
     reviewType: "입양 후기",
     reviewContent:
@@ -234,7 +234,7 @@ export const myReviewMockData: MyReviewItem[] = [
     breederName: "멍 10번째",
     breederLevel: "new",
     applicationDate: "2024. 06. 20.",
-    profileImage: "/avatar-sample.png",
+    profileImage: "",
     animalType: "dog",
     reviewType: "상담 후기",
     reviewContent:

--- a/src/components/breeder-list/breeder-avatar.tsx
+++ b/src/components/breeder-list/breeder-avatar.tsx
@@ -1,10 +1,26 @@
+import Cat from "@/assets/icons/cat";
+import Dog from "@/assets/icons/dog";
 import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
 
-export default function BreederAvatar({ src }: { src: string }) {
+interface BreederAvatarProps {
+  src?: string | null;
+  animal?: "cat" | "dog";
+}
+
+export default function BreederAvatar({
+  src,
+  animal = "dog",
+}: BreederAvatarProps) {
   return (
-    <Avatar className="size-12 ">
-      <AvatarImage src={src} />
-      <AvatarFallback></AvatarFallback>
+    <Avatar className="size-12">
+      {src && <AvatarImage src={src} />}
+      <AvatarFallback>
+        {animal === "cat" ? (
+          <Cat className="size-9 text-grayscale-gray5" />
+        ) : (
+          <Dog className="size-9 text-grayscale-gray5" />
+        )}
+      </AvatarFallback>
     </Avatar>
   );
 }

--- a/src/components/breeder/profile-image-with-badge.tsx
+++ b/src/components/breeder/profile-image-with-badge.tsx
@@ -1,7 +1,9 @@
 import Image from "next/image";
+import Cat from "@/assets/icons/cat";
+import Dog from "@/assets/icons/dog";
 
 interface ProfileImageWithBadgeProps {
-  src: string;
+  src?: string;
   alt: string;
   animalType: "cat" | "dog";
   size?: number;
@@ -15,24 +17,37 @@ export default function ProfileImageWithBadge({
   size = 68,
   className = "",
 }: ProfileImageWithBadgeProps) {
+  const IconComponent = animalType === "cat" ? Cat : Dog;
+
   return (
     <div
-      className={`relative shrink-0 rounded-lg overflow-hidden ${className}`}
+      className={`relative shrink-0 rounded-lg overflow-hidden bg-grayscale-gray1 ${className}`}
       style={{ width: size, height: size }}
     >
-      <Image
-        src={src}
-        alt={alt}
-        width={size}
-        height={size}
-        className="object-cover w-full h-full"
-      />
+      {src ? (
+        <>
+          <Image
+            src={src}
+            alt={alt}
+            width={size}
+            height={size}
+            className="object-cover w-full h-full"
+          />
+          <div className="absolute bottom-0 left-0 right-0 bg-[var(--color-grayscale-gray1)] flex items-center justify-center py-1.5 px-1.5">
+            <p className="text-caption font-medium text-grayscale-gray6 text-center">
+              {animalType === "cat" ? "고양이" : "강아지"}
+            </p>
+          </div>
+        </>
+      ) : (
+        <div className="w-full h-full flex items-center justify-center">
+          <IconComponent
+            className="text-grayscale-gray5"
+            style={{ width: size * 0.7, height: size * 0.7 }}
+          />
+        </div>
+      )}
       {/* 동물 타입 배지 */}
-      <div className="absolute bottom-0 left-0 right-0 bg-[var(--color-grayscale-gray1)] flex items-center justify-center py-1.5 px-1.5">
-        <p className="text-caption font-medium text-grayscale-gray6 text-center">
-          {animalType === "cat" ? "고양이" : "강아지"}
-        </p>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
### 작업 내용


## 브리더 프로필 이미지 분리
- `BreederAvatar` 컴포넌트에 `animal` prop 추가 -> 이미지가 없을 때 Cat/Dog 아이콘 표시
- `BreederProfile` 컴포넌트에서 `avatarUrl`이 없을 때 동물 타입에 맞는 아이콘 렌더링
- `ProfileImageWithBadge` 컴포넌트에서 `src`가 optional로 변경되고 이미지 없을 때 아이콘 표시 지원

## 목데이터 수정
- 탐색 탭 목데이터를 `explore/_mocks/explore-mock-data.ts`로 분리
- `BREEDER_LIST_MOCK`과 `BREEDER_DETAIL_MOCK`에 `animal` 필드 추가


### 연관 이슈
#65 
