### PR TITLE
feat : 닉네임 수정 다이얼로그 UI 및 중복 검사 기능 추가

### DIFF
--- a/src/app/(main)/settings/_components/nickname-edit-dialog.tsx
+++ b/src/app/(main)/settings/_components/nickname-edit-dialog.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  LargeDialog,
+  LargeDialogContent,
+  LargeDialogHeader,
+  LargeDialogTitle,
+  LargeDialogFooter,
+  LargeDialogClose,
+} from "@/components/ui/large-dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { checkNicknameDuplicate } from "@/lib/auth";
+import Close from "@/assets/icons/close";
+import Check from "@/assets/icons/check";
+import ErrorIcon from "@/assets/icons/error";
+
+interface NicknameEditDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentNickname: string;
+  onSave: (nickname: string) => void;
+}
+
+export default function NicknameEditDialog({
+  open,
+  onOpenChange,
+  currentNickname,
+  onSave,
+}: NicknameEditDialogProps) {
+  const [nickname, setNickname] = useState(currentNickname);
+  const [checkingNickname, setCheckingNickname] = useState(false);
+  const [nicknameAvailable, setNicknameAvailable] = useState<boolean | null>(
+    null
+  );
+  const [isModified, setIsModified] = useState(false);
+
+  // 다이얼로그가 열릴 때 currentNickname으로 초기화
+  useEffect(() => {
+    if (open) {
+      setNickname(currentNickname);
+      setIsModified(false);
+      setNicknameAvailable(null);
+    }
+  }, [open, currentNickname]);
+
+  const handleNicknameChange = (value: string) => {
+    setNickname(value);
+    setIsModified(value !== currentNickname);
+    setNicknameAvailable(null);
+  };
+
+  const handleCheckNickname = async () => {
+    if (!nickname || nickname === currentNickname) {
+      return;
+    }
+
+    setCheckingNickname(true);
+    try {
+      const isDuplicate = await checkNicknameDuplicate(nickname);
+      setNicknameAvailable(!isDuplicate);
+    } catch (error) {
+      console.error("닉네임 중복 확인 오류:", error);
+      setNicknameAvailable(false);
+    } finally {
+      setCheckingNickname(false);
+    }
+  };
+
+  const handleSave = () => {
+    if (nicknameAvailable && nickname !== currentNickname) {
+      onSave(nickname);
+      onOpenChange(false);
+      // Reset state
+      setNickname(currentNickname);
+      setIsModified(false);
+      setNicknameAvailable(null);
+    }
+  };
+
+  const handleClose = () => {
+    onOpenChange(false);
+    // Reset to original nickname
+    setNickname(currentNickname);
+    setIsModified(false);
+    setNicknameAvailable(null);
+  };
+
+  const isSaveDisabled =
+    !isModified ||
+    !nicknameAvailable ||
+    nickname === currentNickname ||
+    checkingNickname;
+
+  return (
+    <LargeDialog open={open} onOpenChange={handleClose}>
+      <LargeDialogContent className="w-full md:w-[600px] h-full md:h-[280px] flex flex-col  md:rounded-2xl">
+        {/* Header */}
+        <LargeDialogHeader className="px-5 md:px-6 pt-4 md:pt-6 pb-2.5 md:pb-2.5 border-b-0">
+          <LargeDialogTitle>
+            <div className="flex justify-between items-center gap-1 md:gap-1">
+              <span className="text-body-l font-semibold text-grayscale-gray7 flex-1 text-left">
+                닉네임 수정
+              </span>
+              <LargeDialogClose asChild>
+                <Button variant="secondary" className="size-9 shrink-0">
+                  <Close className="size-5 text-grayscale-gray7" />
+                </Button>
+              </LargeDialogClose>
+            </div>
+          </LargeDialogTitle>
+        </LargeDialogHeader>
+
+        <Separator className="bg-grayscale-gray2" />
+
+        {/* Content */}
+        <div className="flex-1 bg-[#F6F6EA] px-5 md:px-6 py-5 flex flex-col gap-2">
+          <div className="flex flex-col gap-2">
+            <div className="flex gap-3 md:gap-[12px]">
+              <div className="flex-1 flex flex-col gap-[10px]">
+                <Input
+                  value={nickname}
+                  onChange={(e) => handleNicknameChange(e.target.value)}
+                  placeholder="닉네임을 입력하세요"
+                  className="h-12"
+                  disabled={checkingNickname}
+                />
+                {nicknameAvailable === true && (
+                  <div className="flex items-center gap-0.5">
+                    <Check className="size-3 shrink-0 text-status-success-500" />
+                    <p className="text-caption font-medium text-status-success-500">
+                      사용할 수 있는 닉네임이에요
+                    </p>
+                  </div>
+                )}
+                {nicknameAvailable === false && (
+                  <div className="flex items-center gap-[0.12rem]">
+                    <ErrorIcon className="size-3 shrink-0" />
+                    <p className="text-caption font-medium text-status-error-500">
+                      이미 사용 중인 닉네임이에요
+                    </p>
+                  </div>
+                )}
+              </div>
+              <Button
+                variant="tertiary"
+                disabled={
+                  checkingNickname ||
+                  !nickname ||
+                  nickname === currentNickname ||
+                  !isModified
+                }
+                onClick={handleCheckNickname}
+                className="h-12 px-4 shrink-0 text-body-s font-semibold"
+              >
+                {checkingNickname ? "확인 중..." : "중복검사"}
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <Separator className="bg-grayscale-gray2" />
+
+        {/* Footer */}
+        <LargeDialogFooter className="px-5 md:px-6 pt-4 md:pt-4 pb-6 md:pb-6 justify-end border-t-0">
+          <Button
+            variant={
+              nicknameAvailable === true && !isSaveDisabled
+                ? "default"
+                : "secondary"
+            }
+            disabled={
+              !nicknameAvailable ||
+              !isModified ||
+              nickname === currentNickname ||
+              checkingNickname
+            }
+            onClick={handleSave}
+            className="h-9 bg-primary-500 px-4 min-w-[72px] disabled:bg-[#E1E1E1] disabled:text-[#A0A0A0]"
+          >
+            수정
+          </Button>
+        </LargeDialogFooter>
+      </LargeDialogContent>
+    </LargeDialog>
+  );
+}

--- a/src/app/(main)/settings/_components/nickname-section.tsx
+++ b/src/app/(main)/settings/_components/nickname-section.tsx
@@ -1,33 +1,52 @@
 "use client";
 
+import { useState } from "react";
 import Pencil from "@/assets/icons/pencil.svg";
 import { Button } from "@/components/ui/button";
+import NicknameEditDialog from "./nickname-edit-dialog";
 
 interface NicknameSectionProps {
   nickname: string;
-  onEdit?: () => void;
+  onEdit?: (newNickname: string) => void;
 }
 
 export default function NicknameSection({
   nickname,
   onEdit,
 }: NicknameSectionProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const handleSave = (newNickname: string) => {
+    onEdit?.(newNickname);
+    // TODO: 실제 API 호출로 닉네임 업데이트
+    console.log("닉네임 수정:", newNickname);
+  };
+
   return (
-    <div className="flex flex-col gap-5 w-full">
-      <h3 className="text-body-s font-medium text-grayscale-gray5">닉네임</h3>
-      <div className="flex items-center justify-between gap-2 w-full">
-        <span className="text-body-s font-medium text-grayscale-gray6">
-          {nickname}
-        </span>
-        <Button
-          variant="ghost"
-          onClick={onEdit}
-          className="group gap-1 h-auto p-0 text-body-xs font-medium text-grayscale-gray5 hover:text-primary"
-        >
-          <span>수정하기</span>
-          <Pencil className="text-grayscale-gray5 group-hover:text-primary" />
-        </Button>
+    <>
+      <div className="flex flex-col gap-5 w-full">
+        <h3 className="text-body-s font-medium text-grayscale-gray5">닉네임</h3>
+        <div className="flex items-center justify-between gap-2 w-full">
+          <span className="text-body-s font-medium text-grayscale-gray6">
+            {nickname}
+          </span>
+          <Button
+            variant="ghost"
+            onClick={() => setDialogOpen(true)}
+            className="group gap-1 h-auto p-0 text-body-xs font-medium text-grayscale-gray5 hover:text-primary"
+          >
+            <span>수정하기</span>
+            <Pencil className="text-grayscale-gray5 group-hover:text-primary" />
+          </Button>
+        </div>
       </div>
-    </div>
+
+      <NicknameEditDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        currentNickname={nickname}
+        onSave={handleSave}
+      />
+    </>
   );
 }

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -9,12 +9,13 @@ import WithdrawSection from "./_components/withdraw-section";
 
 export default function SettingsPage() {
   const [marketingAgreed, setMarketingAgreed] = useState(true);
-  const [nickname] = useState("포포퐁");
+  const [nickname, setNickname] = useState("포포퐁");
   const [email] = useState("example@gmail.com");
 
-  const handleNicknameEdit = () => {
-    // TODO: 닉네임 수정 로직 구현
-    console.log("닉네임 수정");
+  const handleNicknameEdit = (newNickname: string) => {
+    // TODO: 실제 API 호출로 닉네임 업데이트
+    setNickname(newNickname);
+    console.log("닉네임 수정:", newNickname);
   };
 
   const handleWithdraw = () => {


### PR DESCRIPTION
### 작업 내용

## 닉네임 수정 다이얼로그 추가
**`nickname-edit-dialog.tsx`**
  - 닉네임 수정 모달 구현
  - 닉네임 입력 및 중복 검사 기능
  - 중복 검사 결과에 따른 성공/실패 메시지 표시
  - 중복 검사 통과 여부에 따른 수정 버튼 활성화/비활성화 처리

## 닉네임 중복 검사 기능 구현
  - `checkNicknameDuplicate` API 연동
  - 중복 검사 중 로딩 상태 표시

### 연관 이슈
#67 
