### PR TITLE
feat : 회원 탈퇴 다이얼로그 구현

### DIFF
--- a/src/app/(main)/settings/_components/withdraw-dialog.tsx
+++ b/src/app/(main)/settings/_components/withdraw-dialog.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  LargeDialog,
+  LargeDialogContent,
+  LargeDialogHeader,
+  LargeDialogTitle,
+  LargeDialogFooter,
+  LargeDialogClose,
+} from "@/components/ui/large-dialog";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Textarea } from "@/components/ui/textarea";
+import Close from "@/assets/icons/close";
+import RadioActive from "@/assets/icons/radio-active.svg";
+import RadioInactive from "@/assets/icons/radio-inactive.svg";
+import {
+  withdrawReasons,
+  withdrawTitle,
+  withdrawDescription,
+} from "@/constants/withdraw";
+
+interface WithdrawDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (reason: string, otherReason?: string) => void;
+}
+
+export default function WithdrawDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+}: WithdrawDialogProps) {
+  const [selectedReason, setSelectedReason] = useState<string | null>(null);
+  const [otherReasonText, setOtherReasonText] = useState<string>("");
+  const [isTextareaFocused, setIsTextareaFocused] = useState(false);
+
+  const isOtherSelected = selectedReason === "other";
+
+  // 다이얼로그가 열릴 때 초기화
+  useEffect(() => {
+    if (open) {
+      setSelectedReason(null);
+      setOtherReasonText("");
+      setIsTextareaFocused(false);
+    }
+  }, [open]);
+
+  const handleClose = () => {
+    onOpenChange(false);
+    setSelectedReason(null);
+    setOtherReasonText("");
+    setIsTextareaFocused(false);
+  };
+
+  const handleConfirm = () => {
+    if (selectedReason) {
+      if (isOtherSelected) {
+        onConfirm(selectedReason, otherReasonText);
+      } else {
+        onConfirm(selectedReason);
+      }
+      handleClose();
+    }
+  };
+
+  return (
+    <LargeDialog open={open} onOpenChange={handleClose}>
+      <LargeDialogContent className="w-full md:w-[600px] h-full md:h-auto flex flex-col md:rounded-2xl overflow-hidden">
+        {/* Header */}
+        <LargeDialogHeader className="px-5 md:px-6 pt-4 md:pt-6 pb-2.5 md:pb-2.5 border-b-0">
+          <LargeDialogTitle>
+            <div className="flex justify-end items-center gap-1 md:gap-1">
+              <LargeDialogClose asChild>
+                <Button variant="secondary" className="size-9 shrink-0">
+                  <Close className="size-5 text-grayscale-gray7" />
+                </Button>
+              </LargeDialogClose>
+            </div>
+          </LargeDialogTitle>
+        </LargeDialogHeader>
+
+        <Separator className="bg-grayscale-gray2" />
+
+        {/* Content */}
+        <div
+          className={`bg-[#F6F6EA] px-5 md:px-6 pt-6 md:pt-6 flex flex-1 sm:flex-none flex-col gap-9 md:gap-9 overflow-x-clip overflow-y-auto sm:h-[452px] shrink-0 ${
+            isOtherSelected ? "pb-10" : "pb-[7.44rem]"
+          }`}
+        >
+          {/* Title Section */}
+          <div className="flex flex-col gap-1.5">
+            <h2 className="text-body-l font-semibold text-primary">
+              {withdrawTitle}
+            </h2>
+            <p className="text-caption font-medium text-grayscale-gray5">
+              {withdrawDescription}
+            </p>
+          </div>
+
+          {/* Radio List */}
+          <div className="flex flex-col gap-0">
+            {withdrawReasons.map((reason) => {
+              const isOther = reason.value === "other";
+              return (
+                <div
+                  key={reason.value}
+                  className="flex flex-col items-start relative shrink-0 w-full"
+                >
+                  <button
+                    type="button"
+                    onClick={() => setSelectedReason(reason.value)}
+                    className="flex items-center gap-2 px-0 pr-[10px] py-2 h-9 w-full text-left"
+                  >
+                    {/* Radio Button */}
+                    <div className="relative shrink-0 size-5">
+                      {selectedReason === reason.value ? (
+                        <RadioActive className="size-5" />
+                      ) : (
+                        <RadioInactive className="size-5" />
+                      )}
+                    </div>
+                    {/* Label */}
+                    <span className="text-body-xs font-medium text-grayscale-gray6">
+                      {reason.label}
+                    </span>
+                  </button>
+                  {/* 기타 사유 선택 시 textarea 표시 */}
+                  {isOther && isOtherSelected && (
+                    <div className="bg-white flex flex-col items-start overflow-clip relative rounded-lg shrink-0 w-full">
+                      <div className="box-border flex flex-col items-start overflow-clip pb-0 pt-3 px-4 sm:pt-4 sm:px-4 relative shrink-0 w-full">
+                        <Textarea
+                          placeholder="탈퇴 사유를 최대한 상세히 적어주세요."
+                          value={otherReasonText}
+                          onChange={(e) => {
+                            const value = e.target.value;
+                            if (value.length <= 200) {
+                              setOtherReasonText(value);
+                            }
+                          }}
+                          onFocus={() => setIsTextareaFocused(true)}
+                          onBlur={() => setIsTextareaFocused(false)}
+                          maxLength={200}
+                          showLength={isTextareaFocused}
+                          currentLength={otherReasonText.length}
+                          className="min-h-[12.5rem] font-medium leading-[24px] text-body-s w-full resize-none px-0 pt-0"
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <Separator className="bg-grayscale-gray2" />
+
+        {/* Footer */}
+        <LargeDialogFooter className="px-5 md:px-6 pt-4 md:pt-4 pb-4 md:pb-6 justify-end border-t-0">
+          <button
+            className={`button-brown ${
+              !selectedReason || (isOtherSelected && !otherReasonText.trim())
+                ? "bg-[var(--color-status-disabled)] text-[var(--color-grayscale-gray4)] cursor-not-allowed"
+                : ""
+            }`}
+            onClick={handleConfirm}
+            disabled={
+              !selectedReason || (isOtherSelected && !otherReasonText.trim())
+            }
+          >
+            탈퇴
+          </button>
+        </LargeDialogFooter>
+      </LargeDialogContent>
+    </LargeDialog>
+  );
+}

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -6,11 +6,13 @@ import SocialLoginSection from "./_components/social-login-section";
 import NicknameSection from "./_components/nickname-section";
 import EmailSettingsSection from "./_components/email-settings-section";
 import WithdrawSection from "./_components/withdraw-section";
+import WithdrawDialog from "./_components/withdraw-dialog";
 
 export default function SettingsPage() {
   const [marketingAgreed, setMarketingAgreed] = useState(true);
   const [nickname, setNickname] = useState("포포퐁");
   const [email] = useState("example@gmail.com");
+  const [withdrawDialogOpen, setWithdrawDialogOpen] = useState(false);
 
   const handleNicknameEdit = (newNickname: string) => {
     // TODO: 실제 API 호출로 닉네임 업데이트
@@ -19,8 +21,16 @@ export default function SettingsPage() {
   };
 
   const handleWithdraw = () => {
-    // TODO: 탈퇴 로직 구현
-    console.log("탈퇴하기");
+    setWithdrawDialogOpen(true);
+  };
+
+  const handleWithdrawConfirm = (reason: string, otherReason?: string) => {
+    // TODO: 실제 API 호출로 탈퇴 처리
+    console.log("탈퇴 이유:", reason);
+    if (otherReason) {
+      console.log("기타 사유:", otherReason);
+    }
+    // 탈퇴 처리 후 로그아웃 또는 리다이렉트
   };
 
   return (
@@ -60,6 +70,13 @@ export default function SettingsPage() {
           <WithdrawSection onWithdraw={handleWithdraw} />
         </div>
       </div>
+
+      {/* 탈퇴 다이얼로그 */}
+      <WithdrawDialog
+        open={withdrawDialogOpen}
+        onOpenChange={setWithdrawDialogOpen}
+        onConfirm={handleWithdrawConfirm}
+      />
     </div>
   );
 }

--- a/src/constants/withdraw.ts
+++ b/src/constants/withdraw.ts
@@ -1,0 +1,35 @@
+export interface WithdrawReason {
+  label: string;
+  value: string;
+}
+
+export const withdrawTitle = "그동안 함께 해주셔서 감사해요";
+export const withdrawDescription =
+  "탈퇴 이유를 알려주시면, 더 나은 서비스로 보답할게요!";
+
+export const withdrawReasons: WithdrawReason[] = [
+  {
+    label: "이미 입양을 마쳤어요.",
+    value: "already_adopted",
+  },
+  {
+    label: "마음에 드는 아이가 없어요.",
+    value: "no_suitable_pet",
+  },
+  {
+    label: "입양비가 부담돼요.",
+    value: "adoption_fee_burden",
+  },
+  {
+    label: "사용하기 불편했어요. (UI/기능 등)",
+    value: "uncomfortable_ui",
+  },
+  {
+    label: "개인정보나 보안이 걱정돼요.",
+    value: "privacy_concern",
+  },
+  {
+    label: "다른 이유로 탈퇴하고 싶어요.",
+    value: "other",
+  },
+];


### PR DESCRIPTION
### 작업 내용

## 탈퇴 다이얼로그 구현
 **`withdraw-dialog.tsx`**
  - 라디오 버튼으로 탈퇴 사유 선택
  - 기타 사유 선택 시 textarea 표시
  - 반응형 디자인 적용 (모바일: flex-1, 데스크탑: 고정 높이 452px)
  - 탈퇴 사유 미선택 또는 기타 사유 미입력 시 버튼 비활성화


**`withdraw.ts`**
  - 탈퇴 다이얼로그 제목, 설명
  - 탈퇴 사유 목록 

## 탈퇴 다이얼로그 연결
**`src/app/(main)/settings/page.tsx`**
  - 탈퇴 다이얼로그 컴포넌트 연결


### 연관 이슈
#67 