### PR TITLE
feat : 브리더용 탈퇴 다이얼로그 추가

### DIFF
--- a/src/app/(main)/settings/_components/withdraw-dialog.tsx
+++ b/src/app/(main)/settings/_components/withdraw-dialog.tsx
@@ -17,6 +17,7 @@ import RadioActive from "@/assets/icons/radio-active.svg";
 import RadioInactive from "@/assets/icons/radio-inactive.svg";
 import {
   withdrawReasons,
+  breederWithdrawReasons,
   withdrawTitle,
   withdrawDescription,
 } from "@/constants/withdraw";
@@ -26,12 +27,14 @@ interface WithdrawDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onConfirm: (reason: string, otherReason?: string) => void;
+  userType?: "adopter" | "breeder";
 }
 
 export default function WithdrawDialog({
   open,
   onOpenChange,
   onConfirm,
+  userType = "adopter",
 }: WithdrawDialogProps) {
   const [selectedReason, setSelectedReason] = useState<string | null>(null);
   const [otherReasonText, setOtherReasonText] = useState<string>("");
@@ -40,6 +43,8 @@ export default function WithdrawDialog({
     useState(false);
 
   const isOtherSelected = selectedReason === "other";
+  const isBreeder = userType === "breeder";
+  const reasons = isBreeder ? breederWithdrawReasons : withdrawReasons;
 
   // 다이얼로그가 열릴 때 초기화
   useEffect(() => {
@@ -61,8 +66,8 @@ export default function WithdrawDialog({
 
   const handleReasonSelect = (reason: string) => {
     setSelectedReason(reason);
-    if (reason === "already_adopted") {
-      // 입양 완료 다이얼로그 열기
+    // 일반 사용자이고 "이미 입양을 마쳤어요" 선택 시 입양 완료 다이얼로그 열기
+    if (!isBreeder && reason === "already_adopted") {
       setIsAdoptionCompleteDialogOpen(true);
     }
   };
@@ -132,7 +137,7 @@ export default function WithdrawDialog({
 
             {/* Radio List */}
             <div className="flex flex-col gap-0">
-              {withdrawReasons.map((reason) => {
+              {reasons.map((reason) => {
                 const isOther = reason.value === "other";
                 return (
                   <div

--- a/src/constants/withdraw.ts
+++ b/src/constants/withdraw.ts
@@ -33,3 +33,30 @@ export const withdrawReasons: WithdrawReason[] = [
     value: "other",
   },
 ];
+
+export const breederWithdrawReasons: WithdrawReason[] = [
+  {
+    label: "입양 문의가 잘 오지 않았어요.",
+    value: "no_inquiry",
+  },
+  {
+    label: "운영이 생각보다 번거롭거나 시간이 부족해요.",
+    value: "time_consuming",
+  },
+  {
+    label: "브리더 심사나 검증 절차가 어려웠어요.",
+    value: "verification_difficult",
+  },
+  {
+    label: "수익 구조나 서비스 정책이 잘 맞지 않아요.",
+    value: "policy_mismatch",
+  },
+  {
+    label: "사용하기 불편했어요. (UI/기능 등)",
+    value: "uncomfortable_ui",
+  },
+  {
+    label: "다른 이유로 탈퇴하고 싶어요.",
+    value: "other",
+  },
+];


### PR DESCRIPTION
### 작업 내용


## 브리더용 탈퇴 다이얼로그 구현
**`src/constants/withdraw.ts`**
  - `breederWithdrawReasons` 상수 추가
  - 브리더 전용 탈퇴 사유 6가지 추가

**`src/app/(main)/settings/_components/withdraw-dialog.tsx`**
  - `userType` prop 추가 (기본값: "adopter")
  - 브리더 여부에 따라 탈퇴 사유 목록 동적 변경



### 연관 이슈
#69 
