### PR TITLE
design : 브리더 입점 서류 UI 수정 및 다이얼로그 UI 개선

### DIFF
--- a/src/app/(main)/explore/_components/animal-tabs.tsx
+++ b/src/app/(main)/explore/_components/animal-tabs.tsx
@@ -43,7 +43,7 @@ export default function AnimalTabs() {
               </div>
               <div
                 className={cn("h-[2px] bg-transparent w-full", {
-                  "bg-primary!": active,
+                  "bg-primary-500!": active,
                 })}
               />
             </Button>

--- a/src/app/signup/_components/breeds-select-dialog-trigger.tsx
+++ b/src/app/signup/_components/breeds-select-dialog-trigger.tsx
@@ -74,7 +74,7 @@ export default function BreedsSelectDialogTrigger({
                     {label}
                     <div
                       className={cn("h-0.5 w-full bg-transparent", {
-                        "bg-primary": selectedGroup === label,
+                        "bg-primary-500": selectedGroup === label,
                       })}
                     />
                   </Button>

--- a/src/app/signup/_components/document-skip-dialog-trigger.tsx
+++ b/src/app/signup/_components/document-skip-dialog-trigger.tsx
@@ -43,7 +43,9 @@ export default function DocumentSkipDialogTrigger(
             </Button>
           </SimpleDialogClose>
           <SimpleDialogClose asChild>
-            <Button className="px-4 py-3 text-body-s">이어서 작성</Button>
+            <Button className="px-4 py-3 text-body-s bg-primary-500">
+              이어서 작성
+            </Button>
           </SimpleDialogClose>
         </SimpleDialogFooter>
       </SimpleDialogContent>

--- a/src/app/signup/_components/location-select-dialog-trigger.tsx
+++ b/src/app/signup/_components/location-select-dialog-trigger.tsx
@@ -68,7 +68,7 @@ export default function LocationSelectDialogTrigger({
                     {label}
                     <div
                       className={cn("h-0.5 w-full bg-transparent", {
-                        "bg-primary": selectedGroup === label,
+                        "bg-primary-500": selectedGroup === label,
                       })}
                     />
                   </Button>

--- a/src/app/signup/_components/oath-dialog-trigger.tsx
+++ b/src/app/signup/_components/oath-dialog-trigger.tsx
@@ -16,64 +16,61 @@ const oathInfo: Record<"elite" | "new", React.ReactNode> = {
   elite: (
     <>
       <p>
-        본인은 <span className="text-primary">포퐁 플랫폼 브리더 회원</span>으로
-        입점함에 있어, 아래의 기준을 충실히 준수할 것을 서약합니다. 만약 이를
-        위반하거나 허위 사실이 적발될 경우, 플랫폼에서 즉시 퇴출될 수 있음을
-        이해하며 이에 동의합니다.
+        본인은 포퐁 플랫폼 브리더 회원으로 입점함에 있어, 아래의 기준을 충실히
+        준수할 것을 서약합니다. 만약 이를 위반하거나 허위 사실이 적발될 경우,
+        플랫폼에서 즉시 퇴출될 수 있음을 이해하며 이에 동의합니다.
       </p>
       {[
         <p key={0}>
           본인은{" "}
-          <span className="text-primary">관할 지자체에 동물생산업 등록</span>을
-          완료하였으며, 관련 법규를 성실히 준수합니다.
+          <span className="text-primary-600">
+            관할 지자체에 동물생산업 등록
+          </span>
+          을 완료하였으며, 관련 법규를 성실히 준수합니다.
         </p>,
         <p key={1}>
           모든 분양 과정에서{" "}
-          <span className="text-primary">표준 입양계약서</span>를 작성합니다.
+          <span className="text-primary-600">표준 입양계약서</span>를
+          작성합니다.
         </p>,
         <p key={2}>
-          <span className="text-primary">2종 이하 브리딩 원칙</span>을 지키며,
-          다품종 브리딩을 하지 않습니다.
+          <span className="text-primary-600">2종 이하 브리딩 원칙</span>을
+          지키며, 다품종 브리딩을 하지 않습니다.
         </p>,
         <p key={3}>
           모든 아이들은{" "}
-          <span className="text-primary">중성화 완료 후 분양</span>하거나, 입양
-          계약서에 반드시 중성화 조항을 명시합니다.
+          <span className="text-primary-600">3차 종합백신 완료 후</span>{" "}
+          분양합니다.
         </p>,
         <p key={4}>
-          모든 아이들은{" "}
-          <span className="text-primary">3차 종합백신 완료 후</span> 분양합니다.
+          <span className="text-primary-600">혈통서 발급</span>을 의무화하며,
+          공식 협회 발급 혈통서만 제공합니다.
         </p>,
         <p key={5}>
-          <span className="text-primary">혈통서 발급</span>을 의무화하며, 공식
-          협회 발급 혈통서만 제공합니다.
+          모든 아이들은 반드시{" "}
+          <span className="text-primary-600">생후 3개월 이후</span>에만
+          분양합니다.
         </p>,
         <p key={6}>
-          모든 아이들은 반드시{" "}
-          <span className="text-primary">생후 3개월 이후</span>에만 분양합니다.
-        </p>,
-        <p key={7}>
           국내에서 진행되는 모든 분양은 반드시{" "}
-          <span className="text-primary">대면 분양</span>으로 진행하며,
+          <span className="text-primary-600">대면 분양</span>으로 진행하며,
           비대면·택배 분양은 절대 하지 않습니다.
         </p>,
-        <p key={8}>
+        <p key={7}>
           분양 개체의 사회화, 건강, 복지를 최우선으로 하며, 무분별한 번식을 하지
           않습니다.
         </p>,
-        <p key={9}>
+        <p key={8}>
           포퐁 플랫폼과 입양자에게{" "}
-          <span className="text-primary">
+          <span className="text-primary-600">
             허위 사실 없이 투명하게 정보를 제공
           </span>
           합니다.
         </p>,
-      ].map((e) => (
-        <div className="flex gap-2 items-start" key={e.key}>
-          <div className="h-5 flex items-center">
-            <div className="size-[3px] bg-grayscale-gray5 rounded-full " />
-          </div>
-          {e}
+      ].map((item) => (
+        <div className="flex gap-2 items-center" key={item.key}>
+          <div className="size-[3px] bg-grayscale-gray5 rounded-full shrink-0" />
+          {item}
         </div>
       ))}
     </>
@@ -81,24 +78,26 @@ const oathInfo: Record<"elite" | "new", React.ReactNode> = {
   new: (
     <>
       <p>
-        본인은 <span className="text-primary">포퐁 플랫폼 브리더 회원</span>으로
-        입점함에 있어, 아래의 기준을 충실히 준수할 것을 서약합니다. 만약 이를
-        위반하거나 허위 사실이 적발될 경우, 플랫폼에서 즉시 퇴출될 수 있음을
-        이해하며 이에 동의합니다.
+        본인은 포퐁 플랫폼 브리더 회원으로 입점함에 있어, 아래의 최소 기준을
+        성실히 준수할 것을 서약합니다. 만약 이를 위반하거나 허위 사실이 적발될
+        경우, 플랫폼에서 즉시 퇴출될 수 있음을 이해하며 이에 동의합니다.
       </p>
       {[
         <p key={0}>
           본인은{" "}
-          <span className="text-primary">관할 지자체에 동물생산업 등록</span>을
-          아님을 확인합니다.
+          <span className="text-primary-600">
+            관할 지자체에 동물생산업 등록
+          </span>
+          을 완료하였으며, 법적으로 판매업이 아님을 확인합니다.
         </p>,
         <p key={1}>
           모든 아이들은 반드시{" "}
-          <span className="text-primary">생후 3개월 이후</span>에만 분양합니다.
+          <span className="text-primary-600">생후 3개월 이후</span>에만
+          분양합니다.
         </p>,
         <p key={2}>
           국내에서 진행되는 모든 분양은 반드시{" "}
-          <span className="text-primary">대면 분양</span>으로 진행하며,
+          <span className="text-primary-600">대면 분양</span>으로 진행하며,
           비대면·택배 분양은 절대 하지 않습니다.
         </p>,
         <p key={3}>
@@ -107,17 +106,15 @@ const oathInfo: Record<"elite" | "new", React.ReactNode> = {
         </p>,
         <p key={4}>
           포퐁 플랫폼과 입양자에게{" "}
-          <span className="text-primary">
+          <span className="text-primary-600">
             허위 사실 없이 투명하게 정보를 제공
           </span>
           합니다.
         </p>,
-      ].map((e) => (
-        <div className="flex gap-2 items-start" key={e.key}>
-          <div className="h-5 flex items-center">
-            <div className="size-[3px] bg-grayscale-gray5 rounded-full " />
-          </div>
-          {e}
+      ].map((item) => (
+        <div className="flex gap-2 items-center" key={item.key}>
+          <div className="size-[3px] bg-grayscale-gray5 rounded-full shrink-0" />
+          {item}
         </div>
       ))}
     </>
@@ -138,7 +135,9 @@ export default function OathDialogTrigger({
         <LargeDialogHeader>
           <LargeDialogTitle>
             <div className="flex justify-between items-center">
-              {level === "elite" ? "엘리트" : "뉴"} 레벨 브리더 입점 서약서
+              {level === "elite"
+                ? "엘리트 레벨 브리더 입점 서약서"
+                : "뉴 레벨 브리더 입점 서약서"}
               <LargeDialogClose asChild>
                 <Button variant="secondary" className="size-9">
                   <Close className="size-5 text-grayscale-gray7" />
@@ -149,19 +148,14 @@ export default function OathDialogTrigger({
         </LargeDialogHeader>
 
         <div className="md:py-5 md:px-6 space-y-2 text-body-xs text-grayscale-gray5 overflow-auto px-padding py-4 flex-1">
-          <p>
-            본인은 포퐁 플랫폼 브리더 회원으로 입점함에 있어, 아래의 기준을
-            충실히 준수할 것을 서약합니다. 만약 이를 위반하거나 허위 사실이
-            적발될 경우, 플랫폼에서 즉시 퇴출될 수 있음을 이해하며 이에
-            동의합니다.
-          </p>
           {oathInfo[level]}
         </div>
 
-        <LargeDialogFooter>
+        <LargeDialogFooter className="justify-end">
           <LargeDialogClose asChild>
             <Button
-              className="py-2 px-4 text-sm leading-[140%] tracking-[-2%] w-18 text-white! rounded-[--spacing(1)]"
+              variant="tertiary"
+              className="py-2 px-4 text-sm leading-[140%] text-primary-500 tracking-[-2%] w-18  rounded-[--spacing(1)]"
               onClick={() => {
                 onAgree();
               }}

--- a/src/app/signup/_components/sections/document-section.tsx
+++ b/src/app/signup/_components/sections/document-section.tsx
@@ -46,6 +46,7 @@ const levelInfo = [
 export default function DocumentSection() {
   const level = useSignupFormStore((e) => e.level);
   const setLevel = useSignupFormStore((e) => e.setLevel);
+  const animal = useSignupFormStore((e) => e.animal);
   const [check, setCheck] = useState(false);
   return (
     <SignupFormSection className="gap-15 md:gap-20 lg:gap-20">
@@ -57,71 +58,98 @@ export default function DocumentSection() {
         </SignupFormDescription>
       </SignupFormHeader>
       <SignupFormItems className="gap-8">
-        <div className="grid grid-cols-2 gap-5 items-center">
+        <div className="flex gap-5 items-stretch w-full">
           {levelInfo.map(({ name, icon: Icon, label }) => (
             <Button
               key={name}
               variant="ghost"
-              className="flex flex-col gap-2 bg-transparent p-0 text-grayscale-gray5 hover:text-grayscale-gray6!"
+              className={cn(
+                "flex flex-col gap-2 bg-transparent p-0 text-grayscale-gray5 hover:text-grayscale-gray6! flex-1",
+                {
+                  "text-primary-500": level === name,
+                }
+              )}
               onClick={() => setLevel(name as "elite" | "new")}
             >
-              <div
-                className={cn("flex items-center gap-2 ", {
-                  "text-primary": level === name,
-                })}
-              >
-                <Icon className="size-5" />
+              <div className="flex items-center gap-2 justify-center">
+                <Icon className="size-7" />
                 <div className="text-heading-3 font-semibold">{label}</div>
               </div>
               <div
                 className={cn("h-0.5 w-full bg-transparent", {
-                  "bg-primary": level === name,
+                  "bg-primary-500": level === name,
                 })}
               />
             </Button>
           ))}
         </div>
-        <div className="text-primary/80 font-medium text-body-m text-balance text-center break-keep">
+        <div className="text-primary-500/80 font-medium text-body-m text-balance text-center break-keep">
           {levelInfo.find((e) => e.name === level)?.description}
         </div>
-        <div className="space-y-8">
-          <div className="space-y-2.5">
+        <div className="flex flex-col gap-8 w-full">
+          {/* 신분증 사본 - info 있음 */}
+          <div className="flex flex-col gap-2.5">
             <FileButton>신분증 사본</FileButton>
-            <div className="text-secondary-700 font-medium text-caption-s">
-              이름과 생년월일 이외에는 가려서 제출하시길 권장드립니다.
+            <div className="text-secondary-700 font-medium text-caption">
+              이름과 생년월일 이외에는 가려서 제출하시는 걸 권장드려요.
             </div>
           </div>
-          <div className="space-y-3">
-            <FileButton>동물생산업 등록증</FileButton>
-            {level === "elite" && (
-              <>
-                <FileButton>표준 입양계약서 샘플</FileButton>
 
-                <div className="space-y-2.5">
-                  <FileButton>최근 발급된 혈통서 사본</FileButton>
-                  <div className="text-grayscale-gray5 font-medium text-caption-s">
-                    분양 예정인 개체의 혈통서를 첨부해 주세요
-                  </div>
-                </div>
-              </>
-            )}
+          {/* 동물생산업 등록증, 표준 입양계약서 샘플*/}
+          <div className="flex flex-col gap-3">
+            <FileButton>동물생산업 등록증</FileButton>
+            {level === "elite" && <FileButton>표준 입양계약서 샘플</FileButton>}
           </div>
+
+          {/* 브리더 인증 서류 - info 있음 (elite만) */}
           {level === "elite" && (
-            <div className="space-y-2.5">
-              <FileButton>고양이 브리더 인증 서류</FileButton>
-              <div className="text-grayscale-gray5 font-medium text-caption-s space-y-2">
-                <p>해당되는 서류를 하나 골라 첨부해 주세요</p>
-                {[
-                  "TICA 또는 CFA 등록 확인서 (브리더 회원증/캐터리 등록증)",
-                  "캣쇼 참가 증빙 자료 (참가 확인증, 수상 기록, 공식 프로그램 또는 카탈로그에 게재된 기록 등)",
-                ].map((e, i) => (
-                  <div className="flex gap-1" key={i}>
-                    <div className="h-3 flex items-center">
-                      <div className="size-0.5 rounded-full bg-grayscale-gray5" />
-                    </div>
-                    {e}
-                  </div>
-                ))}
+            <div className="flex flex-col gap-2.5">
+              <FileButton>
+                {animal === "dog"
+                  ? "강아지 브리더 인증 서류"
+                  : "고양이 브리더 인증 서류"}
+              </FileButton>
+              <div className="flex flex-col gap-2">
+                <p className="text-grayscale-gray5 font-medium text-caption">
+                  해당되는 서류를 하나 골라 첨부해 주세요
+                </p>
+                <div className="flex flex-col gap-2">
+                  {animal === "dog" ? (
+                    <>
+                      <div className="flex gap-1 items-start">
+                        <div className="h-3 flex items-center pt-0.5">
+                          <div className="size-0.5 rounded-full bg-grayscale-gray5" />
+                        </div>
+                        <span className="text-grayscale-gray5 font-medium text-caption">
+                          애견연맹견사호등록증
+                        </span>
+                      </div>
+                      <div className="flex gap-1 items-start">
+                        <div className="h-3 flex items-center pt-0.5">
+                          <div className="size-0.5 rounded-full bg-grayscale-gray5" />
+                        </div>
+                        <span className="text-grayscale-gray5 font-medium text-caption">
+                          도그쇼 참가 증빙 자료(참가 확인증, 수상 기록, 공식
+                          프로그램 등에 게재된 기록 등)
+                        </span>
+                      </div>
+                    </>
+                  ) : (
+                    [
+                      "TICA 또는 CFA 등록 확인서 (브리더 회원증/캐터리 등록증)",
+                      "캣쇼 참가 증빙 자료 (참가 확인증, 수상 기록, 공식 프로그램 등에 게재된 기록 등)",
+                    ].map((e, i) => (
+                      <div className="flex gap-1 items-start" key={i}>
+                        <div className="h-3 flex items-center pt-0.5">
+                          <div className="size-0.5 rounded-full bg-grayscale-gray5" />
+                        </div>
+                        <span className="text-grayscale-gray5 font-medium text-caption">
+                          {e}
+                        </span>
+                      </div>
+                    ))
+                  )}
+                </div>
               </div>
             </div>
           )}

--- a/src/app/signup/_components/sections/user-info-section.tsx
+++ b/src/app/signup/_components/sections/user-info-section.tsx
@@ -405,6 +405,8 @@ export default function UserInfoSection() {
         <div className="flex flex-col gap-4">
           <NextButton
             onClick={() => {
+              // 기존 검증 로직 주석처리
+              /*
               let hasError = false;
 
               // 이메일 검증 (소셜 로그인이 아닌 경우만)
@@ -443,6 +445,10 @@ export default function UserInfoSection() {
               if (!hasError) {
                 nextFlowIndex();
               }
+              */
+
+              // 바로 다음 단계로 이동
+              nextFlowIndex();
             }}
           />
           <UndoButton />

--- a/src/components/filter-dialog/filter-dialog-trigger.tsx
+++ b/src/components/filter-dialog/filter-dialog-trigger.tsx
@@ -99,7 +99,7 @@ export default function FilterDialogTrigger({
                   {filterGroup.label}
                   <div
                     className={cn("h-0.5 w-full bg-transparent", {
-                      "bg-primary": isTabSelected,
+                      "bg-primary-500": isTabSelected,
                     })}
                   />
                 </Button>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -14,7 +14,7 @@ function Input({
       placeholder={placeholder}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-grayscale-gray4 selection:bg-primary selection:text-primary-foreground bg-white text-color-primary-500-basic w-full min-w-0 rounded-[--spacing(2)]  px-4 py-3 text-body-s  outline-none file:inline-flex file:border-0 file:bg-transparent file:text-sm font-medium file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 ",
+        "file:text-foreground placeholder:text-grayscale-gray4 selection:bg-primary-500 selection:text-primary-foreground bg-white text-color-primary-500-basic w-full min-w-0 rounded-[--spacing(2)]  px-4 py-3 text-body-s  outline-none file:inline-flex file:border-0 file:bg-transparent file:text-sm font-medium file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 ",
         "focus-visible:ring-0",
         // "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",

--- a/src/components/ui/price-input.tsx
+++ b/src/components/ui/price-input.tsx
@@ -23,7 +23,7 @@ export function PriceInput({
           type="text"
           placeholder={placeholder}
           data-slot="input"
-          className="file:text-foreground placeholder:text-grayscale-gray5 selection:bg-primary selection:text-primary-foreground bg-transparent font-medium text-body-s outline-none file:inline-flex file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:text-grayscale-gray4 w-full"
+          className="file:text-foreground placeholder:text-grayscale-gray5 selection:bg-primary-500 selection:text-primary-foreground bg-transparent font-medium text-body-s outline-none file:inline-flex file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:text-grayscale-gray4 w-full"
           {...props}
         />
       </div>

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -11,7 +11,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-5 w-[34px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent bg-grayscale-gray3 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:border-primary",
+      "peer inline-flex h-5 w-[34px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent bg-grayscale-gray3 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary-500 data-[state=checked]:border-primary-500",
       className
     )}
     {...props}


### PR DESCRIPTION
### 작업 내용

## 스타일 통일 변경 파일
- `bg-primary` → `bg-primary-500`

## 브리더 입점 서류 섹션 레이아웃 개선
  - 파일 업로드 영역을 3개 그룹으로 구분 (신분증, 동물생산업 등록증/표준 입양계약서, 브리더 인증 서류)
  - 각 그룹 사이 간격: `gap-8` (32px)

## 동물 타입별(강아지) 브리더 인증 서류 추가
  - 강아지 선택 시: "강아지 브리더 인증 서류" + 애견연맹견사호등록증, 도그쇼 참가 증빙 자료


## UI 개선
  - 강조 텍스트: `text-primary-600` 적용
  - 동의 버튼 오른쪽 정렬
  - 동의 버튼 스타일: `variant="tertiary"`, `text-primary-500`




### 연관 이슈
#74 
