### PR TITLE
refactor : 브리더 입점 서류 업로드 기능 개선

### DIFF
--- a/src/app/signup/_components/document-skip-dialog-trigger.tsx
+++ b/src/app/signup/_components/document-skip-dialog-trigger.tsx
@@ -19,7 +19,7 @@ export default function DocumentSkipDialogTrigger(
   return (
     <SimpleDialog>
       <SimpleDialogTrigger {...props} />
-      <SimpleDialogContent>
+      <SimpleDialogContent className="px-4 pt-8 pb-5">
         <SimpleDialogHeader>
           <SimpleDialogTitle>
             아직 서류가 준비되지 않으셨나요?
@@ -32,19 +32,18 @@ export default function DocumentSkipDialogTrigger(
 
         <SimpleDialogFooter>
           <SimpleDialogClose asChild>
+            <Button className="px-4 py-3 text-body-s font-semibold bg-secondary-500 text-primary-500 hover:bg-secondary-500 hover:text-primary-500">
+              이어서 작성
+            </Button>
+          </SimpleDialogClose>
+          <SimpleDialogClose asChild>
             <Button
-              variant="tertiary"
-              className="px-4 py-3 text-body-s"
+              className="px-4 py-3 text-body-s font-semibold bg-primary-500 text-secondary-500 hover:bg-primary-500 hover:text-secondary-500"
               onClick={() => {
                 nextFlowIndex();
               }}
             >
               나중에 제출
-            </Button>
-          </SimpleDialogClose>
-          <SimpleDialogClose asChild>
-            <Button className="px-4 py-3 text-body-s bg-primary-500">
-              이어서 작성
             </Button>
           </SimpleDialogClose>
         </SimpleDialogFooter>

--- a/src/app/signup/_components/hooks/use-file-upload.ts
+++ b/src/app/signup/_components/hooks/use-file-upload.ts
@@ -1,0 +1,90 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { z } from "zod";
+
+interface UseFileUploadOptions {
+  onUpload?: (file: File) => void;
+  onDelete?: () => void;
+  file?: File | null;
+  maxSizeMB?: number;
+  errorMessage?: string;
+}
+
+export function useFileUpload({
+  onUpload,
+  onDelete,
+  file,
+  maxSizeMB,
+  errorMessage,
+}: UseFileUploadOptions = {}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [fileName, setFileName] = useState<string>(file?.name ?? "");
+  const [error, setError] = useState<string>("");
+  const fileSchema = useMemo(() => {
+    if (!maxSizeMB) return null;
+    const maxBytes = maxSizeMB * 1024 * 1024;
+    return z.instanceof(File).refine((curFile) => curFile.size <= maxBytes, {
+      message:
+        errorMessage ?? `파일은 최대 ${maxSizeMB}MB까지 업로드할 수 있어요`,
+    });
+  }, [maxSizeMB, errorMessage]);
+
+  useEffect(() => {
+    setFileName(file?.name ?? "");
+    if (file) {
+      setError("");
+    }
+  }, [file]);
+
+  const handleClick = () => {
+    // 파일이 있어도 클릭 가능하게 함
+    // 파일 선택 다이얼로그에서 파일을 선택하면 change 이벤트가 발생하고,
+    // 취소하면 change 이벤트가 발생하지 않아 기존 파일이 유지됨
+    inputRef.current?.click();
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = e.target.files?.[0];
+    if (!selectedFile) {
+      // 파일 선택이 취소된 경우 기존 파일 유지
+      return;
+    }
+
+    if (fileSchema) {
+      const result = fileSchema.safeParse(selectedFile);
+      if (!result.success) {
+        setError(
+          result.error.issues[0]?.message ??
+            `파일은 최대 ${maxSizeMB}MB까지 업로드할 수 있어요`
+        );
+        if (inputRef.current) {
+          inputRef.current.value = "";
+        }
+        return;
+      }
+    }
+
+    // 새 파일 선택 시 기존 파일 삭제하고 새 파일로 교체
+    setError("");
+    setFileName(selectedFile.name);
+    onUpload?.(selectedFile);
+  };
+
+  const handleDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setFileName("");
+    if (inputRef.current) {
+      inputRef.current.value = "";
+    }
+    setError("");
+    onDelete?.();
+  };
+
+  return {
+    inputRef,
+    fileName,
+    handleClick,
+    handleChange,
+    handleDelete,
+    error,
+  };
+}

--- a/src/app/signup/_components/sections/breeder-info-section.tsx
+++ b/src/app/signup/_components/sections/breeder-info-section.tsx
@@ -238,6 +238,7 @@ export default function BreederInfoSection() {
           <UndoButton />
         </div>
       </SignupFormItems>
+      
     </SignupFormSection>
   );
 }

--- a/src/app/signup/_components/sections/document-section.tsx
+++ b/src/app/signup/_components/sections/document-section.tsx
@@ -18,6 +18,14 @@ import DocumentSkipDialogTrigger from "../document-skip-dialog-trigger";
 import OathDialogTrigger from "../oath-dialog-trigger";
 import FileButton from "./file-button";
 
+const DOCUMENT_KEYS = {
+  ID_CARD: "idCard",
+  BUSINESS_LICENSE: "businessLicense",
+  CONTRACT_SAMPLE: "contractSample",
+  BREEDER_DOG: "breederDogCertificate",
+  BREEDER_CAT: "breederCatCertificate",
+} as const;
+
 const levelInfo = [
   {
     name: "elite",
@@ -47,7 +55,20 @@ export default function DocumentSection() {
   const level = useSignupFormStore((e) => e.level);
   const setLevel = useSignupFormStore((e) => e.setLevel);
   const animal = useSignupFormStore((e) => e.animal);
+  const documents = useSignupFormStore((e) => e.documents);
+  const setDocuments = useSignupFormStore((e) => e.setDocuments);
   const [check, setCheck] = useState(false);
+
+  const handleFileUpload = (key: string) => (file: File) => {
+    setDocuments(key, file);
+  };
+
+  const handleFileDelete = (key: string) => () => {
+    setDocuments(key, null);
+  };
+
+  const breederDocKey =
+    animal === "dog" ? DOCUMENT_KEYS.BREEDER_DOG : DOCUMENT_KEYS.BREEDER_CAT;
   return (
     <SignupFormSection className="gap-15 md:gap-20 lg:gap-20">
       <SignupFormHeader>
@@ -89,7 +110,13 @@ export default function DocumentSection() {
         <div className="flex flex-col gap-8 w-full">
           {/* 신분증 사본 - info 있음 */}
           <div className="flex flex-col gap-2.5">
-            <FileButton>신분증 사본</FileButton>
+            <FileButton
+              file={documents[DOCUMENT_KEYS.ID_CARD] ?? null}
+              onUpload={handleFileUpload(DOCUMENT_KEYS.ID_CARD)}
+              onDelete={handleFileDelete(DOCUMENT_KEYS.ID_CARD)}
+            >
+              신분증 사본
+            </FileButton>
             <div className="text-secondary-700 font-medium text-caption">
               이름과 생년월일 이외에는 가려서 제출하시는 걸 권장드려요.
             </div>
@@ -97,14 +124,32 @@ export default function DocumentSection() {
 
           {/* 동물생산업 등록증, 표준 입양계약서 샘플*/}
           <div className="flex flex-col gap-3">
-            <FileButton>동물생산업 등록증</FileButton>
-            {level === "elite" && <FileButton>표준 입양계약서 샘플</FileButton>}
+            <FileButton
+              file={documents[DOCUMENT_KEYS.BUSINESS_LICENSE] ?? null}
+              onUpload={handleFileUpload(DOCUMENT_KEYS.BUSINESS_LICENSE)}
+              onDelete={handleFileDelete(DOCUMENT_KEYS.BUSINESS_LICENSE)}
+            >
+              동물생산업 등록증
+            </FileButton>
+            {level === "elite" && (
+              <FileButton
+                file={documents[DOCUMENT_KEYS.CONTRACT_SAMPLE] ?? null}
+                onUpload={handleFileUpload(DOCUMENT_KEYS.CONTRACT_SAMPLE)}
+                onDelete={handleFileDelete(DOCUMENT_KEYS.CONTRACT_SAMPLE)}
+              >
+                표준 입양계약서 샘플
+              </FileButton>
+            )}
           </div>
 
           {/* 브리더 인증 서류 - info 있음 (elite만) */}
           {level === "elite" && (
             <div className="flex flex-col gap-2.5">
-              <FileButton>
+              <FileButton
+                file={documents[breederDocKey] ?? null}
+                onUpload={handleFileUpload(breederDocKey)}
+                onDelete={handleFileDelete(breederDocKey)}
+              >
                 {animal === "dog"
                   ? "강아지 브리더 인증 서류"
                   : "고양이 브리더 인증 서류"}

--- a/src/app/signup/_components/sections/file-button.tsx
+++ b/src/app/signup/_components/sections/file-button.tsx
@@ -1,34 +1,41 @@
 "use client";
 
 import FileIcon from "@/assets/icons/file";
-import { Button } from "@/components/ui/button";
+import CloseTertiary from "@/assets/icons/close-tertiary.svg";
+import ErrorMessage from "@/components/error-message";
+import { useFileUpload } from "../hooks/use-file-upload";
 import { cn } from "@/lib/utils";
-import { ComponentProps, useRef, useState } from "react";
 
-interface FileButtonProps extends ComponentProps<"button"> {
+interface FileButtonProps {
+  children: React.ReactNode;
+  className?: string;
   onUpload?: (file: File) => void;
+  onDelete?: () => void;
+  file?: File | null;
+  maxSizeMB?: number;
+  errorMessage?: string;
 }
 
 export default function FileButton({
   children,
   className,
   onUpload,
-  ...props
+  onDelete,
+  file,
+  maxSizeMB = 10,
+  errorMessage,
 }: FileButtonProps) {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const [fileName, setFileName] = useState<string>("");
+  const resolvedErrorMessage =
+    errorMessage ?? `파일은 최대 ${maxSizeMB}MB까지 업로드할 수 있어요`;
 
-  const handleClick = () => {
-    inputRef.current?.click();
-  };
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    setFileName(file.name);
-    onUpload?.(file); // ✅ 외부에서 제어 가능
-  };
+  const { inputRef, fileName, handleClick, handleChange, handleDelete, error } =
+    useFileUpload({
+      onUpload,
+      onDelete,
+      file,
+      maxSizeMB,
+      errorMessage: resolvedErrorMessage,
+    });
 
   return (
     <div className="flex flex-col gap-2 w-full">
@@ -38,23 +45,35 @@ export default function FileButton({
         onChange={handleChange}
         className="hidden"
       />
-      <Button
-        variant="input"
-        type="button"
-        onClick={handleClick}
-        className={cn("px-4 py-3 flex items-center justify-between", className)}
-        {...props}
-      >
-        <div className="flex items-center gap-2">
-          <FileIcon className="fill-transparent stroke-grayscale-gray5 size-5" />
-          <div>{children}</div>
-        </div>
-        {fileName && (
-          <div className="text-caption-s text-grayscale-gray5 truncate max-w-[50%] text-right">
-            {fileName}
-          </div>
+      <div
+        className={cn(
+          "bg-white rounded-lg px-4 py-3 flex items-center gap-2 group cursor-pointer",
+          !fileName && "border border-grayscale-gray3",
+          className
         )}
-      </Button>
+        onClick={handleClick}
+      >
+        <FileIcon className="fill-transparent stroke-grayscale-gray5 size-5 shrink-0" />
+        {fileName ? (
+          <span className="text-body-m font-medium text-[#4F3B2E] flex-1 truncate">
+            {fileName}
+          </span>
+        ) : (
+          <span className="text-body-m font-medium text-grayscale-gray5">
+            {children}
+          </span>
+        )}
+        {fileName && (
+          <button
+            type="button"
+            onClick={handleDelete}
+            className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+          >
+            <CloseTertiary className="size-6" />
+          </button>
+        )}
+      </div>
+      {error && <ErrorMessage message={error} />}
     </div>
   );
 }

--- a/src/assets/icons/close-tertiary.svg
+++ b/src/assets/icons/close-tertiary.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="24" height="24" rx="12" fill="#F6F6EA"/>
+<path d="M8.46484 8.46436L15.5359 15.5354" stroke="#545454"/>
+<path d="M15.5352 8.46436L8.46409 15.5354" stroke="#545454"/>
+</svg>


### PR DESCRIPTION
### 작업 내용


## 파일 업로드 기능 개선
- **파일명 표시 UI 수정**: 오른쪽에 표시되던 파일명을 피그마에 맞춰 수정
- **hover 시 삭제 아이콘**: 파일이 있을 때 hover하면 삭제 아이콘(`close-tertiary`) 표시
- **파일 삭제 기능**: 삭제 아이콘 클릭 시 파일이 삭제됩니다
- **파일 재선택**: 파일이 있어도 다시 클릭하여 새 파일을 선택 가능, 취소 시 기존 파일이 유지
- **Zustand store 연동**: 모든 파일 업로드가 `useSignupFormStore`의 `documents` 상태에 저장

## Zod를 활용한 파일 크기 검증
- **10MB 제한**: 기본적으로 파일 크기를 10MB로 제한
- **Zod 스키마 검증**: `z.instanceof(File).refine()`을 사용하여 파일 크기를 검증
- **에러 메시지**: 크기 초과 시 "파일은 최대 10MB까지 업로드할 수 있어요" 메시지가 표시

## 파일 업로드 로직 hooks 분리
**`src/app/signup/_components/hooks/use-file-upload.ts`**
- **`use-file-upload.ts`**: 파일 업로드 관련 로직을 커스텀 훅으로 분리

## "나중에 할래요" 다이얼로그 UI 개선
- **버튼 순서 변경**: "이어서 작성" 버튼이 왼쪽, "나중에 제출" 버튼이 오른쪽에 배치
- **버튼 스타일**: 
  - 이어서 작성: `bg-secondary-500 text-primary-500`
  - 나중에 제출: `bg-primary-500 text-secondary-500`
- **hover 효과 제거**: 버튼 hover 시 색상이 변경되지 않도록 설정
- **패딩 조정**: 상단 32px(`pt-8`), 하단 20px(`pb-5`), 좌우 16px(`px-4`)

## Zustand Store 연동
- `useSignupFormStore`의 `documents` 상태에 파일 저장
- 각 파일은 고유한 키(`DOCUMENT_KEYS`)로 관리
- 파일 삭제 시 store에서도 제거


### 연관 이슈
#49
