### PR TITLE
feat : signup 페이지 이탈 확인 다이얼로그 추가

### DIFF
--- a/src/app/signup/_components/header.tsx
+++ b/src/app/signup/_components/header.tsx
@@ -1,15 +1,19 @@
+"use client";
 import Close from "@/assets/icons/close-primary.svg";
 import Logo from "@/assets/logo/logo";
 import { Button } from "@/components/ui/button";
-import Link from "next/link";
+import ExitConfirmDialog from "@/components/exit-confirmation-dialog";
+import { useRouter } from "next/navigation";
 
 export default function Header() {
+  const router = useRouter();
+
   return (
     <div className="flex justify-between h-16 items-center pl-[1.125rem] pr-5 md:pl-10 md:pr-[2.375rem] lg:pl-12 lg:pr-12 sticky top-0">
       <Button variant={"ghost"} className="w-20">
         <Logo className="text-primary-500 h-6 shrink-0" />
       </Button>
-      <Link href="/">
+      <ExitConfirmDialog hasData={true} onConfirm={() => router.push("/")}>
         <Button
           size="icon"
           variant={"ghost"}
@@ -17,7 +21,7 @@ export default function Header() {
         >
           <Close />
         </Button>
-      </Link>
+      </ExitConfirmDialog>
     </div>
   );
 }


### PR DESCRIPTION
### 작업 내용

## 이탈 확인 다이얼로그 추가
- **기존 동작**: X 버튼 클릭 시 바로 `/`로 이동
- **변경된 동작**: X 버튼 클릭 시 `ExitConfirmDialog`가 먼저 표시되고, "작성 중단" 버튼을 클릭해야 홈으로 이동


### 연관 이슈
#49 
