### PR TITLE
feat: 브리더 입점 서류 수정 페이지 구현 및 공통 컴포넌트 분리

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -15,7 +15,10 @@ export default function Layout({ children }: { children: React.ReactNode }) {
     <QueryProvider>
       <Suspense>
         <NavigationGuardProvider>
-          <Gnb variant={useTertiaryVariant ? "tertiary" : "default"} />
+          <Gnb
+            variant={useTertiaryVariant ? "tertiary" : "default"}
+            navVariant="breeder"
+          />
           {children}
         </NavigationGuardProvider>
       </Suspense>

--- a/src/app/(main)/profile/documents/layout.tsx
+++ b/src/app/(main)/profile/documents/layout.tsx
@@ -1,0 +1,19 @@
+import Container from "@/components/ui/container";
+import React from "react";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="bg-tertiary-500">
+      <Container className="lg:pr-0">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-padding min-h-[calc(100vh-(--spacing(16)))]">
+          <div className="pt-4 pb-padding hidden lg:block w-full sticky top-[--spacing(16)] h-[calc(100vh-(--spacing(16)))]">
+            <div className="relative bg-primary-600 h-full" />
+          </div>
+          <div className="h-full flex justify-center w-full pb-padding">
+            {children}
+          </div>
+        </div>
+      </Container>
+    </div>
+  );
+}

--- a/src/app/(main)/profile/documents/page.tsx
+++ b/src/app/(main)/profile/documents/page.tsx
@@ -1,0 +1,5 @@
+import DocumentEditSection from "@/components/document-form/document-edit-section";
+
+export default function Page() {
+  return <DocumentEditSection />;
+}

--- a/src/app/signup/_components/sections/document-section.tsx
+++ b/src/app/signup/_components/sections/document-section.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import Crown from "@/assets/icons/crown";
-import Plant from "@/assets/icons/plant";
 import SignupFormDescription from "@/components/signup-form-section/signup-form-description";
 import SignupFormHeader from "@/components/signup-form-section/signup-form-header";
 import SignupFormItems from "@/components/signup-form-section/signup-form-items";
@@ -9,47 +7,11 @@ import SignupFormSection from "@/components/signup-form-section/signup-form-sect
 import SignupFormTitle from "@/components/signup-form-section/signup-form-title";
 import UndoButton from "@/components/signup-form-section/undo-button";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
-import { cn } from "@/lib/utils";
+import DocumentFormContent from "@/components/document-form/document-form-content";
 import useSignupFormStore from "@/stores/signup-form-store";
-import { ChevronRight } from "lucide-react";
 import { useState } from "react";
 import DocumentSkipDialogTrigger from "../document-skip-dialog-trigger";
-import OathDialogTrigger from "../oath-dialog-trigger";
-import FileButton from "./file-button";
-
-const DOCUMENT_KEYS = {
-  ID_CARD: "idCard",
-  BUSINESS_LICENSE: "businessLicense",
-  CONTRACT_SAMPLE: "contractSample",
-  BREEDER_DOG: "breederDogCertificate",
-  BREEDER_CAT: "breederCatCertificate",
-} as const;
-
-const levelInfo = [
-  {
-    name: "elite",
-    icon: Crown,
-    label: "Elite 엘리트",
-    description:
-      "엘리트 레벨은 전문성과 윤리적 기준을 증명해 차별화된 신뢰와 가치를 제공하는 상위 레벨이에요.",
-    documents: [
-      "신분증 사본",
-      "동물생산업 등록증",
-      "표준 입양계약서 샘플",
-      "최근 발급된 혈통서 사본",
-      "고양이 브리더 인증 서류",
-    ],
-  },
-  {
-    name: "new",
-    icon: Plant,
-    label: "New 뉴",
-    description:
-      "뉴 레벨은 법적 필수 요건만 충족하면 입점할 수 있는, 막 시작한 브리더를 위한 기본 신뢰 레벨이에요.",
-    documents: ["신분증 사본", "동물생산업 등록증"],
-  },
-];
+import type { Level } from "@/components/document-form/document-constants";
 
 export default function DocumentSection() {
   const level = useSignupFormStore((e) => e.level);
@@ -57,7 +19,7 @@ export default function DocumentSection() {
   const animal = useSignupFormStore((e) => e.animal);
   const documents = useSignupFormStore((e) => e.documents);
   const setDocuments = useSignupFormStore((e) => e.setDocuments);
-  const [check, setCheck] = useState(false);
+  const [oathChecked, setOathChecked] = useState(false);
 
   const handleFileUpload = (key: string) => (file: File) => {
     setDocuments(key, file);
@@ -67,8 +29,6 @@ export default function DocumentSection() {
     setDocuments(key, null);
   };
 
-  const breederDocKey =
-    animal === "dog" ? DOCUMENT_KEYS.BREEDER_DOG : DOCUMENT_KEYS.BREEDER_CAT;
   return (
     <SignupFormSection className="gap-15 md:gap-20 lg:gap-20">
       <SignupFormHeader>
@@ -78,168 +38,17 @@ export default function DocumentSection() {
           서류를 업로드해주세요.
         </SignupFormDescription>
       </SignupFormHeader>
-      <SignupFormItems className="gap-8">
-        <div className="flex gap-5 items-stretch w-full">
-          {levelInfo.map(({ name, icon: Icon, label }) => (
-            <Button
-              key={name}
-              variant="ghost"
-              className={cn(
-                "flex flex-col gap-2 bg-transparent p-0 text-grayscale-gray5 hover:text-grayscale-gray6! flex-1",
-                {
-                  "text-primary-500": level === name,
-                }
-              )}
-              onClick={() => setLevel(name as "elite" | "new")}
-            >
-              <div className="flex items-center gap-2 justify-center">
-                <Icon className="size-7" />
-                <div className="text-heading-3 font-semibold">{label}</div>
-              </div>
-              <div
-                className={cn("h-0.5 w-full bg-transparent", {
-                  "bg-primary-500": level === name,
-                })}
-              />
-            </Button>
-          ))}
-        </div>
-        <div className="text-primary-500/80 font-medium text-body-m text-balance text-center break-keep">
-          {levelInfo.find((e) => e.name === level)?.description}
-        </div>
-        <div className="flex flex-col gap-8 w-full">
-          {/* 신분증 사본 - info 있음 */}
-          <div className="flex flex-col gap-2.5">
-            <FileButton
-              file={documents[DOCUMENT_KEYS.ID_CARD] ?? null}
-              onUpload={handleFileUpload(DOCUMENT_KEYS.ID_CARD)}
-              onDelete={handleFileDelete(DOCUMENT_KEYS.ID_CARD)}
-            >
-              신분증 사본
-            </FileButton>
-            <div className="text-secondary-700 font-medium text-caption">
-              이름과 생년월일 이외에는 가려서 제출하시는 걸 권장드려요.
-            </div>
-          </div>
-
-          {/* 동물생산업 등록증, 표준 입양계약서 샘플*/}
-          <div className="flex flex-col gap-3">
-            <FileButton
-              file={documents[DOCUMENT_KEYS.BUSINESS_LICENSE] ?? null}
-              onUpload={handleFileUpload(DOCUMENT_KEYS.BUSINESS_LICENSE)}
-              onDelete={handleFileDelete(DOCUMENT_KEYS.BUSINESS_LICENSE)}
-            >
-              동물생산업 등록증
-            </FileButton>
-            {level === "elite" && (
-              <FileButton
-                file={documents[DOCUMENT_KEYS.CONTRACT_SAMPLE] ?? null}
-                onUpload={handleFileUpload(DOCUMENT_KEYS.CONTRACT_SAMPLE)}
-                onDelete={handleFileDelete(DOCUMENT_KEYS.CONTRACT_SAMPLE)}
-              >
-                표준 입양계약서 샘플
-              </FileButton>
-            )}
-          </div>
-
-          {/* 브리더 인증 서류 - info 있음 (elite만) */}
-          {level === "elite" && (
-            <div className="flex flex-col gap-2.5">
-              <FileButton
-                file={documents[breederDocKey] ?? null}
-                onUpload={handleFileUpload(breederDocKey)}
-                onDelete={handleFileDelete(breederDocKey)}
-              >
-                {animal === "dog"
-                  ? "강아지 브리더 인증 서류"
-                  : "고양이 브리더 인증 서류"}
-              </FileButton>
-              <div className="flex flex-col gap-2">
-                <p className="text-grayscale-gray5 font-medium text-caption">
-                  해당되는 서류를 하나 골라 첨부해 주세요
-                </p>
-                <div className="flex flex-col gap-2">
-                  {animal === "dog" ? (
-                    <>
-                      <div className="flex gap-1 items-start">
-                        <div className="h-3 flex items-center pt-0.5">
-                          <div className="size-0.5 rounded-full bg-grayscale-gray5" />
-                        </div>
-                        <span className="text-grayscale-gray5 font-medium text-caption">
-                          애견연맹견사호등록증
-                        </span>
-                      </div>
-                      <div className="flex gap-1 items-start">
-                        <div className="h-3 flex items-center pt-0.5">
-                          <div className="size-0.5 rounded-full bg-grayscale-gray5" />
-                        </div>
-                        <span className="text-grayscale-gray5 font-medium text-caption">
-                          도그쇼 참가 증빙 자료(참가 확인증, 수상 기록, 공식
-                          프로그램 등에 게재된 기록 등)
-                        </span>
-                      </div>
-                    </>
-                  ) : (
-                    [
-                      "TICA 또는 CFA 등록 확인서 (브리더 회원증/캐터리 등록증)",
-                      "캣쇼 참가 증빙 자료 (참가 확인증, 수상 기록, 공식 프로그램 등에 게재된 기록 등)",
-                    ].map((e, i) => (
-                      <div className="flex gap-1 items-start" key={i}>
-                        <div className="h-3 flex items-center pt-0.5">
-                          <div className="size-0.5 rounded-full bg-grayscale-gray5" />
-                        </div>
-                        <span className="text-grayscale-gray5 font-medium text-caption">
-                          {e}
-                        </span>
-                      </div>
-                    ))
-                  )}
-                </div>
-              </div>
-            </div>
-          )}
-          <OathDialogTrigger
-            className="cursor-pointer"
-            onAgree={() => {
-              setCheck(true);
-            }}
-            asChild
-            level={level}
-          >
-            <div className="flex items-center">
-              <div className="flex-1 flex items-center gap-2 py-2 pr-2.5 font-medium">
-                <div className="size-5 flex items-center justify-center">
-                  <Checkbox
-                    checked={check}
-                    onClick={(e) => {
-                      if (check === true) {
-                        e.stopPropagation();
-                        setCheck(false);
-                      }
-                    }}
-                  />
-                </div>
-                <span className="text-body-xs text-grayscale-gray6 select-none">
-                  (필수) {level === "elite" ? "엘리트" : "뉴"} 레벨 브리더 입점
-                  서약서
-                </span>
-              </div>
-
-              <Button
-                variant="ghost"
-                className="flex items-center gap-2.5 text-grayscale-gray5 text-body-xs"
-              >
-                <div>보기</div>
-                <div className="size-5 flex items-center justify-center">
-                  <ChevronRight className="size-4" />
-                </div>
-              </Button>
-            </div>
-          </OathDialogTrigger>
-        </div>
-      </SignupFormItems>
-
-      <SignupFormItems className="gap-4 ">
+      <DocumentFormContent
+        level={level as Level}
+        animal={animal ?? "cat"}
+        documents={documents}
+        oathChecked={oathChecked}
+        onLevelChange={(newLevel) => setLevel(newLevel as "elite" | "new")}
+        onFileUpload={handleFileUpload}
+        onFileDelete={handleFileDelete}
+        onOathCheckedChange={setOathChecked}
+      />
+      <SignupFormItems className="gap-4">
         <div className="flex gap-3">
           <DocumentSkipDialogTrigger asChild>
             <Button

--- a/src/app/signup/_components/sections/file-button.tsx
+++ b/src/app/signup/_components/sections/file-button.tsx
@@ -48,7 +48,6 @@ export default function FileButton({
       <div
         className={cn(
           "bg-white rounded-lg px-4 py-3 flex items-center gap-2 group cursor-pointer",
-          !fileName && "border border-grayscale-gray3",
           className
         )}
         onClick={handleClick}

--- a/src/components/document-form/document-constants.ts
+++ b/src/components/document-form/document-constants.ts
@@ -1,0 +1,40 @@
+import Crown from "@/assets/icons/crown";
+import Plant from "@/assets/icons/plant";
+import type { ComponentType } from "react";
+
+export const DOCUMENT_KEYS = {
+  ID_CARD: "idCard",
+  BUSINESS_LICENSE: "businessLicense",
+  CONTRACT_SAMPLE: "contractSample",
+  BREEDER_DOG: "breederDogCertificate",
+  BREEDER_CAT: "breederCatCertificate",
+} as const;
+
+export type DocumentKey = (typeof DOCUMENT_KEYS)[keyof typeof DOCUMENT_KEYS];
+
+export type Level = "elite" | "new";
+export type Animal = "dog" | "cat";
+
+export interface LevelInfo {
+  name: Level;
+  icon: ComponentType<{ className?: string }>;
+  label: string;
+  description: string;
+}
+
+export const LEVEL_INFO: LevelInfo[] = [
+  {
+    name: "elite",
+    icon: Crown,
+    label: "Elite 엘리트",
+    description:
+      "엘리트 레벨은 전문성과 윤리적 기준을 증명해 차별화된 신뢰와 가치를 제공하는 상위 레벨이에요.",
+  },
+  {
+    name: "new",
+    icon: Plant,
+    label: "New 뉴",
+    description:
+      "뉴 레벨은 법적 필수 요건만 충족하면 입점할 수 있는, 막 시작한 브리더를 위한 기본 신뢰 레벨이에요.",
+  },
+];

--- a/src/components/document-form/document-edit-section.tsx
+++ b/src/components/document-form/document-edit-section.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import SignupFormItems from "@/components/signup-form-section/signup-form-items";
+import SignupFormSection from "@/components/signup-form-section/signup-form-section";
+import { Button } from "@/components/ui/button";
+import DocumentFormContent from "@/components/document-form/document-form-content";
+import { useState } from "react";
+import type {
+  Animal,
+  Level,
+} from "@/components/document-form/document-constants";
+
+export default function DocumentEditSection() {
+  const [level, setLevel] = useState<Level>("elite");
+  const [documents, setDocuments] = useState<Record<string, File | null>>({});
+  const [oathChecked, setOathChecked] = useState(false);
+  const [animal] = useState<Animal>("cat"); // TODO: 실제 동물 타입 가져오기
+
+  const handleFileUpload = (key: string) => (file: File) => {
+    setDocuments((prev) => ({ ...prev, [key]: file }));
+  };
+
+  const handleFileDelete = (key: string) => () => {
+    setDocuments((prev) => ({ ...prev, [key]: null }));
+  };
+
+  const handleSubmit = () => {
+    // TODO: 서류 제출 로직 구현
+    console.log("서류 제출", { level, documents, oathChecked });
+  };
+
+  return (
+    <SignupFormSection className="gap-15  mt-[3.5rem] md:gap-20 lg:gap-20">
+      <DocumentFormContent
+        level={level}
+        animal={animal}
+        documents={documents}
+        oathChecked={oathChecked}
+        onLevelChange={setLevel}
+        onFileUpload={handleFileUpload}
+        onFileDelete={handleFileDelete}
+        onOathCheckedChange={setOathChecked}
+      />
+      <SignupFormItems className="gap-4">
+        <Button
+          variant="tertiary"
+          className="py-3 px-4 w-full"
+          onClick={handleSubmit}
+          disabled={!oathChecked}
+        >
+          제출
+        </Button>
+      </SignupFormItems>
+    </SignupFormSection>
+  );
+}
+

--- a/src/components/document-form/document-form-content.tsx
+++ b/src/components/document-form/document-form-content.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import SignupFormItems from "@/components/signup-form-section/signup-form-items";
+import { LEVEL_INFO, type Animal, type Level } from "./document-constants";
+import DocumentUploadFields from "./document-upload-fields";
+import LevelTabs from "./level-tabs";
+import OathCheckbox from "./oath-checkbox";
+
+interface DocumentFormContentProps {
+  level: Level;
+  animal: Animal;
+  documents: Record<string, File | null>;
+  oathChecked: boolean;
+  onLevelChange: (level: Level) => void;
+  onFileUpload: (key: string) => (file: File) => void;
+  onFileDelete: (key: string) => () => void;
+  onOathCheckedChange: (checked: boolean) => void;
+}
+
+export default function DocumentFormContent({
+  level,
+  animal,
+  documents,
+  oathChecked,
+  onLevelChange,
+  onFileUpload,
+  onFileDelete,
+  onOathCheckedChange,
+}: DocumentFormContentProps) {
+  return (
+    <SignupFormItems className="gap-8">
+      <LevelTabs level={level} onLevelChange={onLevelChange} />
+      <div className="text-primary-500/80 font-medium text-body-m text-balance text-center break-keep">
+        {LEVEL_INFO.find((e) => e.name === level)?.description}
+      </div>
+      <div className="flex flex-col gap-8 w-full">
+        <DocumentUploadFields
+          level={level}
+          animal={animal}
+          documents={documents}
+          onFileUpload={onFileUpload}
+          onFileDelete={onFileDelete}
+        />
+        <OathCheckbox
+          level={level}
+          checked={oathChecked}
+          onCheckedChange={onOathCheckedChange}
+        />
+      </div>
+    </SignupFormItems>
+  );
+}

--- a/src/components/document-form/document-upload-fields.tsx
+++ b/src/components/document-form/document-upload-fields.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import FileButton from "@/app/signup/_components/sections/file-button";
+import { DOCUMENT_KEYS, type Animal, type Level } from "./document-constants";
+
+interface DocumentUploadFieldsProps {
+  level: Level;
+  animal: Animal;
+  documents: Record<string, File | null>;
+  onFileUpload: (key: string) => (file: File) => void;
+  onFileDelete: (key: string) => () => void;
+}
+
+export default function DocumentUploadFields({
+  level,
+  animal,
+  documents,
+  onFileUpload,
+  onFileDelete,
+}: DocumentUploadFieldsProps) {
+  const breederDocKey =
+    animal === "dog" ? DOCUMENT_KEYS.BREEDER_DOG : DOCUMENT_KEYS.BREEDER_CAT;
+
+  return (
+    <div className="flex flex-col gap-8 w-full">
+      {/* 신분증 사본 - info 있음 */}
+      <div className="flex flex-col gap-2.5">
+        <FileButton
+          file={documents[DOCUMENT_KEYS.ID_CARD] ?? null}
+          onUpload={onFileUpload(DOCUMENT_KEYS.ID_CARD)}
+          onDelete={onFileDelete(DOCUMENT_KEYS.ID_CARD)}
+        >
+          신분증 사본
+        </FileButton>
+        <div className="text-secondary-700 font-medium text-caption">
+          이름과 생년월일 이외에는 가려서 제출하시는 걸 권장드려요.
+        </div>
+      </div>
+
+      {/* 동물생산업 등록증, 표준 입양계약서 샘플*/}
+      <div className="flex flex-col gap-3">
+        <FileButton
+          file={documents[DOCUMENT_KEYS.BUSINESS_LICENSE] ?? null}
+          onUpload={onFileUpload(DOCUMENT_KEYS.BUSINESS_LICENSE)}
+          onDelete={onFileDelete(DOCUMENT_KEYS.BUSINESS_LICENSE)}
+        >
+          동물생산업 등록증
+        </FileButton>
+        {level === "elite" && (
+          <FileButton
+            file={documents[DOCUMENT_KEYS.CONTRACT_SAMPLE] ?? null}
+            onUpload={onFileUpload(DOCUMENT_KEYS.CONTRACT_SAMPLE)}
+            onDelete={onFileDelete(DOCUMENT_KEYS.CONTRACT_SAMPLE)}
+          >
+            표준 입양계약서 샘플
+          </FileButton>
+        )}
+      </div>
+
+      {/* 브리더 인증 서류 - info 있음 (elite만) */}
+      {level === "elite" && (
+        <div className="flex flex-col gap-2.5">
+          <FileButton
+            file={documents[breederDocKey] ?? null}
+            onUpload={onFileUpload(breederDocKey)}
+            onDelete={onFileDelete(breederDocKey)}
+          >
+            {animal === "dog"
+              ? "강아지 브리더 인증 서류"
+              : "고양이 브리더 인증 서류"}
+          </FileButton>
+          <div className="flex flex-col gap-2">
+            <p className="text-grayscale-gray5 font-medium text-caption">
+              해당되는 서류를 하나 골라 첨부해 주세요
+            </p>
+            <div className="flex flex-col gap-2">
+              {animal === "dog" ? (
+                <>
+                  <div className="flex gap-1 items-start">
+                    <div className="h-3 flex items-center pt-0.5">
+                      <div className="size-0.5 rounded-full bg-grayscale-gray5" />
+                    </div>
+                    <span className="text-grayscale-gray5 font-medium text-caption">
+                      애견연맹견사호등록증
+                    </span>
+                  </div>
+                  <div className="flex gap-1 items-start">
+                    <div className="h-3 flex items-center pt-0.5">
+                      <div className="size-0.5 rounded-full bg-grayscale-gray5" />
+                    </div>
+                    <span className="text-grayscale-gray5 font-medium text-caption">
+                      도그쇼 참가 증빙 자료(참가 확인증, 수상 기록, 공식
+                      프로그램 등에 게재된 기록 등)
+                    </span>
+                  </div>
+                </>
+              ) : (
+                [
+                  "TICA 또는 CFA 등록 확인서 (브리더 회원증/캐터리 등록증)",
+                  "캣쇼 참가 증빙 자료 (참가 확인증, 수상 기록, 공식 프로그램 등에 게재된 기록 등)",
+                ].map((e, i) => (
+                  <div className="flex gap-1 items-start" key={i}>
+                    <div className="h-3 flex items-center pt-0.5">
+                      <div className="size-0.5 rounded-full bg-grayscale-gray5" />
+                    </div>
+                    <span className="text-grayscale-gray5 font-medium text-caption">
+                      {e}
+                    </span>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/document-form/level-tabs.tsx
+++ b/src/components/document-form/level-tabs.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { LEVEL_INFO, type Level } from "./document-constants";
+
+interface LevelTabsProps {
+  level: Level;
+  onLevelChange: (level: Level) => void;
+}
+
+export default function LevelTabs({ level, onLevelChange }: LevelTabsProps) {
+  return (
+    <div className="flex gap-5 items-stretch w-full">
+      {LEVEL_INFO.map(({ name, icon: Icon, label }) => (
+        <Button
+          key={name}
+          variant="ghost"
+          className={cn(
+            "flex flex-col gap-2 bg-transparent p-0 text-grayscale-gray5 hover:text-grayscale-gray6! flex-1",
+            {
+              "text-primary-500": level === name,
+            }
+          )}
+          onClick={() => onLevelChange(name)}
+        >
+          <div className="flex items-center gap-2 justify-center">
+            <Icon className="size-7" />
+            <div className="text-heading-3 font-semibold">{label}</div>
+          </div>
+          <div
+            className={cn("h-0.5 w-full bg-transparent", {
+              "bg-primary-500": level === name,
+            })}
+          />
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/document-form/oath-checkbox.tsx
+++ b/src/components/document-form/oath-checkbox.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import OathDialogTrigger from "@/app/signup/_components/oath-dialog-trigger";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { ChevronRight } from "lucide-react";
+import { type Level } from "./document-constants";
+
+interface OathCheckboxProps {
+  level: Level;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+export default function OathCheckbox({
+  level,
+  checked,
+  onCheckedChange,
+}: OathCheckboxProps) {
+  return (
+    <OathDialogTrigger
+      className="cursor-pointer"
+      onAgree={() => {
+        onCheckedChange(true);
+      }}
+      asChild
+      level={level}
+    >
+      <div className="flex items-center">
+        <div className="flex-1 flex items-center gap-2 py-2 pr-2.5 font-medium">
+          <div className="size-5 flex items-center justify-center">
+            <Checkbox
+              checked={checked}
+              onClick={(e) => {
+                if (checked === true) {
+                  e.stopPropagation();
+                  onCheckedChange(false);
+                }
+              }}
+            />
+          </div>
+          <span className="text-body-xs text-grayscale-gray6 select-none">
+            (필수) {level === "elite" ? "엘리트" : "뉴"} 레벨 브리더 입점 서약서
+          </span>
+        </div>
+
+        <Button
+          variant="ghost"
+          className="flex items-center gap-2.5 text-grayscale-gray5 text-body-xs"
+        >
+          <div>보기</div>
+          <div className="size-5 flex items-center justify-center">
+            <ChevronRight className="size-4" />
+          </div>
+        </Button>
+      </div>
+    </OathDialogTrigger>
+  );
+}
+

--- a/src/components/gnb/gnb.tsx
+++ b/src/components/gnb/gnb.tsx
@@ -7,9 +7,13 @@ import NavButton from "./nav-button";
 import NoticeButton from "./notice-button";
 interface GnbProps {
   variant?: "default" | "tertiary";
+  navVariant?: "default" | "breeder";
 }
 
-export default function Gnb({ variant = "default" }: GnbProps) {
+export default function Gnb({
+  variant = "default",
+  navVariant = "breeder",
+}: GnbProps) {
   const isLg = useBreakpoint("lg");
   const bgClass = variant === "tertiary" ? "bg-tertiary-500" : "bg-background";
 
@@ -17,10 +21,10 @@ export default function Gnb({ variant = "default" }: GnbProps) {
     <div className={bgClass}>
       <Container className="h-16 flex items-center justify-between">
         <LogoButton />
-        {isLg && <NavBar />}
+        {isLg && <NavBar navVariant={navVariant} />}
         <div className="flex gap-4 items-center">
           <NoticeButton />
-          {!isLg && <NavButton />}
+          {!isLg && <NavButton navVariant={navVariant} />}
         </div>
       </Container>
     </div>

--- a/src/components/gnb/nav-button.tsx
+++ b/src/components/gnb/nav-button.tsx
@@ -5,7 +5,11 @@ import { Button } from "../ui/button";
 import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "../ui/sheet";
 import MobileNavMenu from "./mobile-nav-menu";
 
-export default function NavButton() {
+interface NavButtonProps {
+  navVariant?: "default" | "breeder";
+}
+
+export default function NavButton({ navVariant = "breeder" }: NavButtonProps) {
   return (
     <Sheet>
       <SheetTrigger asChild>
@@ -17,7 +21,7 @@ export default function NavButton() {
       </SheetTrigger>
       <SheetContent side="right" className="w-full">
         <SheetTitle className="sr-only">모바일 내비게이션</SheetTitle>
-        <MobileNavMenu />
+        <MobileNavMenu navVariant={navVariant} />
       </SheetContent>
     </Sheet>
   );


### PR DESCRIPTION
### 작업 내용

## 입점 서류 수정 페이지 생성
**`/profile/documents`**
- Elite/New 레벨 선택, 파일 업로드, 서약서 동의 기능 포함

## 공통 컴포넌트 분리 및 리팩터링
**`src/components/document-form/`**
- 회원가입(`signup`)과 입점 서류 수정(`profile/documents`) 페이지에서 공통으로 사용

## UI 수정
- 파일 업로드 버튼의 border 제거

## GNB 메뉴 설정
- 브리더용 GNB 메뉴 활성화 (임시 설정)
- `navVariant="breeder"`로 설정하여 "입점 서류 수정" 메뉴 표시

###  파일 구조

### 새로 생성된 파일

```
src/
├── app/
│   └── (main)/
│       └── profile/
│           └── documents/
│               ├── layout.tsx          # 2-column 레이아웃
│               └── page.tsx            # 입점 서류 수정 페이지 진입점
│
└── components/
    └── document-form/                   # 공통 문서 폼 컴포넌트
        ├── document-constants.ts        # 상수 및 타입 정의 (DOCUMENT_KEYS, LEVEL_INFO)
        ├── document-edit-section.tsx   # 입점 서류 수정 섹션 (제출 버튼 포함)
        ├── document-form-content.tsx    # 문서 폼 컨텐츠 (레벨 탭, 파일 업로드, 서약서)
        ├── document-upload-fields.tsx  # 파일 업로드 필드 컴포넌트
        ├── level-tabs.tsx               # Elite/New 레벨 탭 컴포넌트
        └── oath-checkbox.tsx            # 서약서 체크박스 컴포넌트
```




### 연관 이슈
#74 