### PR TITLE
design : 서약서 다이얼로그 넓이 변경

### DIFF
--- a/src/app/signup/_components/oath-dialog-trigger.tsx
+++ b/src/app/signup/_components/oath-dialog-trigger.tsx
@@ -124,10 +124,13 @@ const oathInfo: Record<"elite" | "new", React.ReactNode> = {
 export default function OathDialogTrigger({
   onAgree,
   level,
+  isReadOnly = false,
   ...props
-}: { onAgree: () => void; level: "elite" | "new" } & React.ComponentProps<
-  typeof DialogPrimitive.Trigger
->) {
+}: {
+  onAgree: () => void;
+  level: "elite" | "new";
+  isReadOnly?: boolean;
+} & React.ComponentProps<typeof DialogPrimitive.Trigger>) {
   return (
     <LargeDialog>
       <LargeDialogTrigger {...props} />
@@ -157,8 +160,11 @@ export default function OathDialogTrigger({
               variant="tertiary"
               className="py-2 px-4 text-sm leading-[140%] text-primary-500 tracking-[-2%] w-18  rounded-[--spacing(1)]"
               onClick={() => {
-                onAgree();
+                if (!isReadOnly) {
+                  onAgree();
+                }
               }}
+              disabled={isReadOnly}
             >
               동의
             </Button>

--- a/src/components/document-form/oath-checkbox.tsx
+++ b/src/components/document-form/oath-checkbox.tsx
@@ -4,6 +4,7 @@ import OathDialogTrigger from "@/app/signup/_components/oath-dialog-trigger";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { type Level } from "./document-constants";
 
 interface OathCheckboxProps {
@@ -17,26 +18,39 @@ export default function OathCheckbox({
   checked,
   onCheckedChange,
 }: OathCheckboxProps) {
+  // 팝업에서 한번 동의하면 Read-only 상태 (checked가 true이면 Read-only)
+  const isReadOnly = checked;
+
   return (
     <OathDialogTrigger
       className="cursor-pointer"
       onAgree={() => {
         onCheckedChange(true);
       }}
+      isReadOnly={isReadOnly}
       asChild
       level={level}
     >
       <div className="flex items-center">
         <div className="flex-1 flex items-center gap-2 py-2 pr-2.5 font-medium">
-          <div className="size-5 flex items-center justify-center">
+          <div
+            className="size-5 flex items-center justify-center"
+            onClick={(e) => {
+              // 체크박스 영역 클릭 시 팝업이 열리도록 이벤트 전파
+              // Read-only 상태에서도 팝업은 열 수 있어야 함
+            }}
+          >
             <Checkbox
               checked={checked}
+              disabled={isReadOnly}
               onClick={(e) => {
-                if (checked === true) {
-                  e.stopPropagation();
-                  onCheckedChange(false);
+                // 체크박스 자체 클릭은 이벤트 전파 (팝업 열기)
+                // Read-only 상태에서는 해제 불가능하므로 이벤트만 전파
+                if (isReadOnly) {
+                  return;
                 }
               }}
+              className={cn(isReadOnly && "cursor-default")}
             />
           </div>
           <span className="text-body-xs text-grayscale-gray6 select-none">
@@ -57,4 +71,3 @@ export default function OathCheckbox({
     </OathDialogTrigger>
   );
 }
-

--- a/src/components/ui/large-dialog.tsx
+++ b/src/components/ui/large-dialog.tsx
@@ -60,7 +60,7 @@ function LargeDialogContent({
       {...props}
       showCloseButton={false}
       className={cn(
-        "max-w-150 rounded-none sm:rounded-[--spacing(4)] p-0 gap-0 h-full w-full md:w-auto md:h-auto md:max-h-full flex flex-col",
+        "max-w-150 rounded-none sm:rounded-[--spacing(4)] p-0 gap-0 h-full w-full md:w-full md:max-w-150 md:h-auto md:max-h-full flex flex-col",
         className
       )}
     >


### PR DESCRIPTION
### 작업 내용
## 서약서 다이얼로그 넓이 변경
**`large-dialog.tsx `** 
- md:w-auto를 md:w-full md:max-w-150으로 변경
- 패드에서도 데스크탑과 동일한 최대 너비(max-w-150) 적용


### 연관 이슈
#74 