### PR TITLE
feat : 알림 빈 상태 UI 구현

### DIFF
--- a/src/components/notification/notification-dialog.tsx
+++ b/src/components/notification/notification-dialog.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/dialog";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import NotificationItem from "./notification-item";
+import NotificationEmptyState from "./notification-empty-state";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
@@ -26,101 +27,7 @@ interface NotificationData {
 }
 
 // 목 데이터
-const mockNotifications: NotificationData[] = [
-  {
-    id: 1,
-    type: "BREEDER_APPROVED",
-    date: "2024. 01. 15. 10:00",
-    isRead: false,
-  },
-  {
-    id: 2,
-    type: "BREEDER_UNAPPROVED",
-    date: "2024. 01. 14. 14:30",
-    isRead: false,
-  },
-  {
-    id: 3,
-    type: "BREEDER_ONBOARDING_INCOMPLETE",
-    date: "2024. 01. 13. 09:15",
-    isRead: false,
-  },
-  {
-    id: 4,
-    type: "NEW_CONSULT_REQUEST",
-    date: "2024. 01. 12. 16:45",
-    isRead: false,
-  },
-  {
-    id: 5,
-    type: "NEW_REVIEW_REGISTERED",
-    date: "2024. 01. 11. 11:20",
-    isRead: true,
-  },
-  {
-    id: 6,
-    type: "CONSULT_COMPLETED",
-    date: "2024. 01. 10. 13:00",
-    isRead: true,
-    variables: { breederName: "홍길동" },
-  },
-  {
-    id: 7,
-    type: "NEW_PET_REGISTERED",
-    date: "2024. 01. 09. 15:30",
-    isRead: true,
-    variables: { breederName: "김철수" },
-  },
-  {
-    id: 8,
-    type: "NEW_PET_REGISTERED",
-    date: "2024. 01. 09. 15:30",
-    isRead: true,
-    variables: { breederName: "김철수" },
-  },
-  {
-    id: 9,
-    type: "NEW_PET_REGISTERED",
-    date: "2024. 01. 09. 15:30",
-    isRead: true,
-    variables: { breederName: "김철수" },
-  },
-  {
-    id: 10,
-    type: "NEW_PET_REGISTERED",
-    date: "2024. 01. 09. 15:30",
-    isRead: true,
-    variables: { breederName: "김철수" },
-  },
-  {
-    id: 11,
-    type: "NEW_PET_REGISTERED",
-    date: "2024. 01. 09. 15:30",
-    isRead: true,
-    variables: { breederName: "김철수" },
-  },
-  {
-    id: 12,
-    type: "NEW_PET_REGISTERED",
-    date: "2024. 01. 09. 15:30",
-    isRead: true,
-    variables: { breederName: "김철수" },
-  },
-  {
-    id: 13,
-    type: "NEW_PET_REGISTERED",
-    date: "2024. 01. 09. 15:30",
-    isRead: true,
-    variables: { breederName: "김철수" },
-  },
-  {
-    id: 14,
-    type: "NEW_PET_REGISTERED",
-    date: "2024. 01. 09. 15:30",
-    isRead: true,
-    variables: { breederName: "김철수" },
-  },
-];
+const mockNotifications: NotificationData[] = [];
 
 interface NotificationDialogProps {
   children: React.ReactNode;
@@ -174,7 +81,11 @@ export default function NotificationDialog({
     <Dialog>
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent
-        className="fixed inset-x-0 top-[64px] bottom-0 w-full max-w-full p-0 flex flex-col overflow-hidden translate-x-0 translate-y-0 rounded-none border-0 lg:w-[480px] lg:h-[816px] lg:max-w-[480px] lg:max-h-[816px] lg:top-[64px] lg:right-[48px] lg:left-auto lg:rounded-2xl lg:shadow-[0px_0px_13px_0px_rgba(12,17,29,0.08)]  data-[state=open]:slide-in-from-right-full data-[state=closed]:slide-out-to-right-full "
+        className={`fixed inset-x-0 top-[64px] bottom-0 w-full max-w-full p-0 flex flex-col overflow-hidden translate-x-0 translate-y-0 rounded-none border-0 lg:w-[480px] lg:max-w-[480px] lg:top-[64px] lg:right-[48px] lg:left-auto lg:bottom-auto lg:rounded-2xl lg:shadow-[0px_0px_13px_0px_rgba(12,17,29,0.08)] data-[state=open]:slide-in-from-right-full data-[state=closed]:slide-out-to-right-full ${
+          notifications.length > 0
+            ? "lg:h-[816px] lg:max-h-[816px]"
+            : "lg:h-auto lg:max-h-none"
+        }`}
         overlayClassName="inset-0 bg-transparent"
         showCloseButton={false}
       >
@@ -186,84 +97,96 @@ export default function NotificationDialog({
         {/* 헤더 */}
         <div className="hidden lg:flex justify-between items-center px-6 pt-6 pb-[10px]">
           <h2 className="text-body-l font-semibold text-primary">알림</h2>
-          <Button
-            variant="ghost"
-            onClick={handleMarkAllAsRead}
-            className="text-body-xs font-normal text-[#4E9CF1] underline hover:no-underline p-0 h-auto"
-          >
-            모두 읽음으로 표시
-          </Button>
+          {notifications.length > 0 && (
+            <Button
+              variant="ghost"
+              onClick={handleMarkAllAsRead}
+              className="text-body-xs font-normal text-[#4E9CF1] underline hover:no-underline p-0 h-auto"
+            >
+              모두 읽음으로 표시
+            </Button>
+          )}
         </div>
 
         {/* 스크롤 가능한 콘텐츠 영역 */}
-        <ScrollArea className="flex-1 min-h-0 px-5 md:px-10 lg:px-[12px] lg:pb-6">
-          <div className="flex flex-col gap-6 ">
-            {/* 신규 섹션 */}
-            {newNotifications.length > 0 && (
-              <div className="flex flex-col gap-[10px]">
-                <div className="flex items-center px-3">
-                  <p className="text-body-xs font-semibold text-grayscale-gray5">
-                    신규
-                  </p>
+        <ScrollArea
+          className={`${
+            notifications.length > 0 ? "flex-1 min-h-0" : "flex-none"
+          } px-5 md:px-10 lg:px-[12px] lg:pb-6`}
+        >
+          {notifications.length === 0 ? (
+            <NotificationEmptyState />
+          ) : (
+            <div className="flex flex-col gap-6 ">
+              {/* 신규 섹션 */}
+              {newNotifications.length > 0 && (
+                <div className="flex flex-col gap-[10px]">
+                  <div className="flex items-center px-3">
+                    <p className="text-body-xs font-semibold text-grayscale-gray5">
+                      신규
+                    </p>
+                  </div>
+                  <div className="flex flex-col">
+                    {newNotifications.map((notification) => (
+                      <NotificationItem
+                        key={notification.id}
+                        icon={getNotificationIcon(
+                          notification.type,
+                          notification.variables
+                        )}
+                        content={getNotificationMessage(
+                          notification.type,
+                          notification.variables
+                        )}
+                        date={notification.date}
+                      />
+                    ))}
+                  </div>
                 </div>
-                <div className="flex flex-col">
-                  {newNotifications.map((notification) => (
-                    <NotificationItem
-                      key={notification.id}
-                      icon={getNotificationIcon(
-                        notification.type,
-                        notification.variables
-                      )}
-                      content={getNotificationMessage(
-                        notification.type,
-                        notification.variables
-                      )}
-                      date={notification.date}
-                    />
-                  ))}
-                </div>
-              </div>
-            )}
+              )}
 
-            {/* 읽음 섹션 */}
-            {readNotifications.length > 0 && (
-              <div className="flex flex-col gap-[10px]">
-                <div className="flex items-center px-3">
-                  <p className="text-body-xs font-semibold text-grayscale-gray5">
-                    읽음
-                  </p>
+              {/* 읽음 섹션 */}
+              {readNotifications.length > 0 && (
+                <div className="flex flex-col gap-[10px]">
+                  <div className="flex items-center px-3">
+                    <p className="text-body-xs font-semibold text-grayscale-gray5">
+                      읽음
+                    </p>
+                  </div>
+                  <div className="flex flex-col">
+                    {readNotifications.map((notification) => (
+                      <NotificationItem
+                        key={notification.id}
+                        icon={getNotificationIcon(
+                          notification.type,
+                          notification.variables
+                        )}
+                        content={getNotificationMessage(
+                          notification.type,
+                          notification.variables
+                        )}
+                        date={notification.date}
+                      />
+                    ))}
+                  </div>
                 </div>
-                <div className="flex flex-col">
-                  {readNotifications.map((notification) => (
-                    <NotificationItem
-                      key={notification.id}
-                      icon={getNotificationIcon(
-                        notification.type,
-                        notification.variables
-                      )}
-                      content={getNotificationMessage(
-                        notification.type,
-                        notification.variables
-                      )}
-                      date={notification.date}
-                    />
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
+              )}
+            </div>
+          )}
         </ScrollArea>
 
         {/* 하단 버튼 (모바일/패드용) */}
-        <div className="lg:hidden flex  px-5 md:px-10 pb-4 border-grayscale-gray2 flex-shrink-0">
-          <Button
-            variant="ghost"
-            onClick={handleMarkAllAsRead}
-            className="text-body-xs font-normal text-[#4E9CF1] underline hover:no-underline p-0 h-auto"
-          >
-            모두 읽음으로 표시
-          </Button>
-        </div>
+        {notifications.length > 0 && (
+          <div className="lg:hidden flex  px-5 md:px-10 pb-4 border-grayscale-gray2 flex-shrink-0">
+            <Button
+              variant="ghost"
+              onClick={handleMarkAllAsRead}
+              className="text-body-xs font-normal text-[#4E9CF1] underline hover:no-underline p-0 h-auto"
+            >
+              모두 읽음으로 표시
+            </Button>
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/notification/notification-empty-state.tsx
+++ b/src/components/notification/notification-empty-state.tsx
@@ -1,0 +1,14 @@
+import Alarm from "@/assets/icons/alarm";
+
+export default function NotificationEmptyState() {
+  return (
+    <div className="flex flex-col items-center py-[120px]">
+      <div className="flex flex-col items-center gap-7">
+        <Alarm className="w-[2.70831rem] h-[2.54938rem] text-grayscale-gray4" />
+        <p className="text-body-l font-semibold text-grayscale-gray5">
+          아직 도착한 알림이 없어요.
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### 작업 내용

- 알림이 없을 때 빈 상태(Empty State) UI 구현
- 알림 다이얼로그 높이를 알림 유무에 따라 동적으로 조절
- 빈 상태 컴포넌트 분리 (`NotificationEmptyState`)



## 빈 상태 컴포넌트 추가
- `src/components/notification/notification-empty-state.tsx` 생성
- 알림 아이콘과 "아직 도착한 알림이 없어요." 메시지 표시

## 알림 다이얼로그 개선
- 알림이 없을 때: 다이얼로그 높이를 내용에 맞게 자동 조절 (`lg:h-auto`)
- 알림이 있을 때: 고정 높이 유지 (`lg:h-[816px]`)
- ScrollArea의 flex 속성을 알림 유무에 따라 조건부 적용
  - 알림 있음: `flex-1 min-h-0` (스크롤 가능)
  - 알림 없음: `flex-none` (내용에 맞게 조절)




### 연관 이슈
#95 
