### PR TITLE
design : 상담 신청하기 버튼을 폼 영역 너비 기준 중앙 정렬로 수정

### DIFF
--- a/src/app/(main)/counselform/page.tsx
+++ b/src/app/(main)/counselform/page.tsx
@@ -584,7 +584,7 @@ export default function CounselFormPage() {
           </div>
 
           {/* 제출 버튼 */}
-          <div className="fixed bottom-6 left-1/2 -translate-x-1/2 px-8 w-full max-w-[424px] md:bottom-10 md:left-[calc(50%+20%)] md:-translate-x-1/2 md:w-[424px] md:px-0">
+          <div className="sticky bottom-6 flex w-full justify-center px-8 md:bottom-10 md:px-4 lg:px-0.5">
             <Button
               variant={undefined}
               disabled={isDisabled}


### PR DESCRIPTION
### 작업 내용

## 상담 신청하기 버튼 위치 개선
- 상담 신청하기 버튼 컨테이너를 폼 본문 영역안에서 sticky 하단 정렬로 변경
- 데스크톱(1440px+)에서도 폼 영역 너비에 맞춰 좌우 중앙 정렬 유지

### 연관 이슈

