### PR TITLE
design : 분양 중인 아이들 더보기 버튼 삭제

### DIFF
--- a/src/app/(main)/_components/home-breeder-grid.tsx
+++ b/src/app/(main)/_components/home-breeder-grid.tsx
@@ -20,7 +20,6 @@ export default function HomeBreederGrid() {
       <div className="flex flex-col gap-7">
         <BreederProfileSectionHeader>
           <BreederProfileSectionTitle>분양 중인 아이들</BreederProfileSectionTitle>
-          <BreederProfileSectionMore />
         </BreederProfileSectionHeader>
         <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-3 gap-6">
           {animals.map((animal) => (


### PR DESCRIPTION
### 작업 내용

##  분양 중인 아이들 더보기 버튼 삭제
- 홈 화면에서의 분양중인 아이들 섹션 더보기 버튼 삭제

### 연관 이슈
#118 