### PR TITLE
fix : explore 진입 시 강아지 탭 기본 설정

### DIFF
--- a/src/app/(main)/explore/_components/site-breeder-list.tsx
+++ b/src/app/(main)/explore/_components/site-breeder-list.tsx
@@ -33,7 +33,7 @@ export default function SiteBreederList() {
   const isLoggedIn = !!user;
 
   // URL 경로에서 petType 자동 감지 (useSegment 사용)
-  const petType = (useSegment(1) as 'cat' | 'dog') || 'cat';
+  const petType = (useSegment(1) as 'cat' | 'dog') || 'dog';
 
   // URL 쿼리 파라미터에서 정렬 옵션 가져오기
   const searchParams = useSearchParams();

--- a/src/hooks/use-animal.tsx
+++ b/src/hooks/use-animal.tsx
@@ -4,7 +4,7 @@ import { useSegment } from './use-segment';
 
 export default function useAnimal(): 'cat' | 'dog' {
   const setAnimal = useFilterStore((state) => state.setAnimal);
-  const animal = (useSegment(1) as 'cat' | 'dog') || 'cat';
+  const animal = (useSegment(1) as 'cat' | 'dog') || 'dog';
   const clearActiveFilters = useFilterStore((state) => state.clearActiveFilters);
   // animal 값이 변경될 때마다 스토어의 상태를 업데이트합니다.
   useEffect(() => {


### PR DESCRIPTION
### 작업 내용
## /explore 페이지 접근 시 기본 동물 타입을 고양이에서 강아지로 변경
- site-breeder-list.tsx: petType 기본값을 'cat'에서 'dog'로 변경
- use-animal.tsx: animal 기본값을 'cat'에서 'dog'로 변경

### 연관 이슈

관련이슈 번호를 close해주세요.
#116 
