### PR TITLE
feat : (후기 작성) 다이얼로그 '보기' 버튼 기능 추가

### DIFF
--- a/src/app/(main)/application/_components/review-dialog.tsx
+++ b/src/app/(main)/application/_components/review-dialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import { Dialog, DialogContent, DialogTrigger, DialogClose, DialogTitle } from '@/components/ui/dialog';
 import SmallDot from '@/assets/icons/small-dot.svg';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
@@ -30,6 +31,7 @@ interface ReviewDialogProps {
 
 export default function ReviewDialog({
   applicationId,
+  breederId,
   breederName,
   breederLevel,
   applicationDate,
@@ -37,6 +39,7 @@ export default function ReviewDialog({
   animalType,
   children,
 }: ReviewDialogProps) {
+  const router = useRouter();
   const [showReviewWriteDialog, setShowReviewWriteDialog] = useState(false);
   const [open, setOpen] = useState(false);
   const [applicationData, setApplicationData] = useState<ApplicationDetailDto | null>(null);
@@ -102,7 +105,13 @@ export default function ReviewDialog({
                   className="gap-3"
                 />
               </div>
-              <Button className="gap-1 text-grayscale-gray5 text-body-xs h-auto p-0 has-[>svg]:px-0 hover:bg-transparent">
+              <Button
+                className="gap-1 text-grayscale-gray5 text-body-xs h-auto p-0 has-[>svg]:px-0 hover:bg-transparent"
+                onClick={() => {
+                  setOpen(false);
+                  router.push(`/explore/breeder/${breederId}`);
+                }}
+              >
                 <span>보기</span>
                 <RightArrow className="size-5" />
               </Button>
@@ -361,6 +370,7 @@ export default function ReviewDialog({
       {/* 후기 작성 다이얼로그 */}
       <ReviewWriteDialog
         applicationId={applicationId}
+        breederId={breederId}
         open={showReviewWriteDialog}
         onOpenChange={setShowReviewWriteDialog}
         breederName={breederName}

--- a/src/app/(main)/application/_components/review-write-dialog.tsx
+++ b/src/app/(main)/application/_components/review-write-dialog.tsx
@@ -19,6 +19,7 @@ interface ReviewWriteDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   applicationId: string;
+  breederId: string;
   breederName: string;
   breederLevel: 'elite' | 'new';
   applicationDate: string;
@@ -30,6 +31,7 @@ export default function ReviewWriteDialog({
   open,
   onOpenChange,
   applicationId,
+  breederId,
   breederName,
   breederLevel,
   applicationDate,
@@ -115,7 +117,13 @@ export default function ReviewWriteDialog({
                 className="gap-3"
               />
             </div>
-            <Button className="gap-1 text-grayscale-gray5 text-body-xs h-auto p-0 has-[>svg]:px-0 hover:bg-transparent">
+            <Button
+              className="gap-1 text-grayscale-gray5 text-body-xs h-auto p-0 has-[>svg]:px-0 hover:bg-transparent"
+              onClick={() => {
+                onOpenChange(false);
+                router.push(`/explore/breeder/${breederId}`);
+              }}
+            >
               <span>보기</span>
               <RightArrow className="size-5" />
             </Button>

--- a/src/app/(main)/application/_hooks/use-applications.ts
+++ b/src/app/(main)/application/_hooks/use-applications.ts
@@ -40,7 +40,7 @@ const mapAdopterDtoToApplicationItem = (dto: ApplicationListItemDto): Applicatio
   breederName: dto.breederName,
   breederLevel: dto.breederLevel,
   applicationDate: dto.applicationDate,
-  // 프로필 이미지가 있으면 그대로 사용, 없으면 빈 문자열 (기본 아이콘 표시)
+  // 탐색 화면과 동일하게 API에서 받은 profileImage를 그대로 사용
   profileImage: dto.profileImage || '',
   animalType: dto.animalType,
   petId: dto.petId,


### PR DESCRIPTION
### 작업 내용

## 후기 작성 다이얼로그 "보기" 버튼 기능 추가
- 후기 작성 다이얼로그의 "보기" 버튼 클릭 시 해당 브리더의 상세 페이지로 이동
  - 신청 내역 상세 다이얼로그 (`review-dialog.tsx`)
  - 후기 작성 다이얼로그 (`review-write-dialog.tsx`)



### 연관 이슈
#116