### PR TITLE
feat: 받은 신청 다이얼로그 UI 개선 및 완료 취소 기능 추가

### DIFF
--- a/src/app/(main)/application/_components/application-detail-modal.tsx
+++ b/src/app/(main)/application/_components/application-detail-modal.tsx
@@ -45,6 +45,28 @@ const ApplicationDetailModal = ({ open, onOpenChange, applicationId }: Applicati
     },
   });
 
+  const cancelConsultationMutation = useMutation({
+    mutationFn: () =>
+      updateApplicationStatus(applicationId, {
+        applicationId,
+        status: 'consultation_pending',
+      }),
+    onSuccess: () => {
+      toast({
+        title: '완료 취소',
+        description: '상담 완료가 취소되었습니다.',
+      });
+      queryClient.invalidateQueries({ queryKey: ['application', applicationId] });
+      queryClient.invalidateQueries({ queryKey: ['applications'] });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: '오류',
+        description: error.message || '완료 취소 처리 중 오류가 발생했습니다.',
+      });
+    },
+  });
+
   if (isLoading) {
     return (
       <Dialog open={open} onOpenChange={onOpenChange}>
@@ -80,6 +102,10 @@ const ApplicationDetailModal = ({ open, onOpenChange, applicationId }: Applicati
 
   const handleCompleteConsultation = () => {
     completeConsultationMutation.mutate();
+  };
+
+  const handleCancelConsultation = () => {
+    cancelConsultationMutation.mutate();
   };
 
   return (
@@ -341,15 +367,25 @@ const ApplicationDetailModal = ({ open, onOpenChange, applicationId }: Applicati
             </div>
           )}
           {application.status === 'consultation_completed' ? (
-            <Button
-              disabled
-              className="h-9 px-4 bg-[#E1E1E1] text-[#A0A0A0] text-sm font-medium rounded min-w-[72px] cursor-not-allowed ml-auto"
-            >
-              상담 완료
-            </Button>
+            <div className="flex items-center gap-2 ml-auto">
+              <Button
+                variant="tertiary"
+                className="h-9 px-4 bg-[#A0C8F4] hover:bg-[#77B2F3] text-[#4F3B2E] text-sm font-medium rounded"
+                onClick={handleCancelConsultation}
+                disabled={cancelConsultationMutation.isPending}
+              >
+                완료 취소
+              </Button>
+              <Button
+                disabled
+                className="h-9 px-4 bg-[#E1E1E1] text-[#A0A0A0] text-sm font-medium rounded min-w-[72px] cursor-not-allowed"
+              >
+                상담 완료
+              </Button>
+            </div>
           ) : (
             <Button
-              className="h-9 px-4 bg-[#4F3B2E] hover:bg-[#3E2F23] text-white text-sm font-medium rounded min-w-[72px]"
+              className="h-9 px-4 bg-[#4F3B2E] hover:bg-[#3E2F23] text-white text-sm font-medium rounded min-w-[72px] ml-auto"
               onClick={handleCompleteConsultation}
               disabled={completeConsultationMutation.isPending}
             >


### PR DESCRIPTION
### 작업 내용

## 다이얼로그 크기 및 스타일 조정
- **데스크탑 (lg 이상)**: `width: 37.5rem`, `height: 37.5rem` 고정 크기
- **모바일/패드**: 전체 화면에 꽉 차게 표시 (`w-full h-full`)
- **Border 제거**: `border-none` 적용
- **반응형 처리**: 모바일에서는 `rounded-none`, 데스크탑에서는 `rounded-2xl` 유지

## 완료 취소 기능 추가
- 상담 완료 상태일 때 "완료 취소" 버튼 추가
- "완료 취소" 버튼이 "상담 완료" 버튼 왼쪽에 8px 간격으로 배치
- 완료 취소 시 상태를 `consultation_pending`으로 변경
- 헤더 배지가 자동으로 "상담 전"으로 업데이트


### 연관 이슈
#116 
