### PR TITLE
feat: 홈 화면 FAQ 클릭 시 해당 질문이 열린 상태로 이동 및 로직 훅 분리

### DIFF
--- a/src/app/(main)/_components/faq.tsx
+++ b/src/app/(main)/_components/faq.tsx
@@ -87,9 +87,11 @@ const FAQ = () => {
           {faqs.map((item) => (
             <div key={item.faqId}>
               <div className="h-px bg-[#e4e7ec] w-full" />
-              <div className="py-5">
-                <p className="text-body-m font-medium text-primary-500">{item.question}</p>
-              </div>
+              <Link href={`/faq?faqId=${item.faqId}&userType=${user?.role === 'breeder' ? 'breeder' : 'adopter'}`}>
+                <div className="py-5 cursor-pointer">
+                  <p className="text-body-m font-medium text-primary-500">{item.question}</p>
+                </div>
+              </Link>
             </div>
           ))}
           <div className="h-px bg-[#e4e7ec] w-full" />
@@ -104,9 +106,11 @@ const FAQ = () => {
             {leftColumn.map((item) => (
               <div key={item.faqId}>
                 <div className="h-px bg-[#e4e7ec] w-full" />
-                <div className="py-5">
-                  <p className="text-body-m font-medium text-primary">{item.question}</p>
-                </div>
+                <Link href={`/faq?faqId=${item.faqId}&userType=${user?.role === 'breeder' ? 'breeder' : 'adopter'}`}>
+                  <div className="py-5 cursor-pointer ">
+                    <p className="text-body-m font-medium text-primary">{item.question}</p>
+                  </div>
+                </Link>
               </div>
             ))}
             <div className="h-px bg-[#e4e7ec] w-full" />
@@ -117,9 +121,11 @@ const FAQ = () => {
             {rightColumn.map((item) => (
               <div key={item.faqId}>
                 <div className="h-px bg-[#e4e7ec] w-full" />
-                <div className="py-5">
-                  <p className="text-body-m font-medium text-primary">{item.question}</p>
-                </div>
+                <Link href={`/faq?faqId=${item.faqId}&userType=${user?.role === 'breeder' ? 'breeder' : 'adopter'}`}>
+                  <div className="py-5 cursor-pointer hover:bg-[#F6F6EA] transition-colors">
+                    <p className="text-body-m font-medium text-primary">{item.question}</p>
+                  </div>
+                </Link>
               </div>
             ))}
             <div className="h-px bg-[#e4e7ec] w-full" />

--- a/src/app/(main)/faq/_hooks/use-faq-page.ts
+++ b/src/app/(main)/faq/_hooks/use-faq-page.ts
@@ -1,0 +1,101 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useAuthStore } from '@/stores/auth-store';
+import { useFaqs } from './use-faqs';
+import type { FaqDto } from '@/lib/home';
+
+type TabType = 'adopter' | 'breeder';
+
+export function useFaqPage() {
+  const { user } = useAuthStore();
+  const searchParams = useSearchParams();
+  const faqIdFromUrl = searchParams.get('faqId');
+  const userTypeFromUrl = searchParams.get('userType') as TabType | null;
+
+  const [activeTab, setActiveTab] = useState<TabType>(() => {
+    // URL 파라미터 우선, 없으면 로그인한 사용자의 역할에 따라 초기 탭 설정
+    if (userTypeFromUrl === 'breeder' || userTypeFromUrl === 'adopter') {
+      return userTypeFromUrl;
+    }
+    return user?.role === 'breeder' ? 'breeder' : 'adopter';
+  });
+  const [openIndex, setOpenIndex] = useState<number | null>(0);
+  const [showAll, setShowAll] = useState(false);
+
+  const { data: faqs = [], isLoading, error } = useFaqs(activeTab);
+
+  // 로그인 상태 변경 시 탭 업데이트 (URL 파라미터가 없을 때만)
+  useEffect(() => {
+    if (!userTypeFromUrl) {
+      if (user?.role === 'breeder') {
+        setActiveTab('breeder');
+      } else if (user?.role === 'adopter') {
+        setActiveTab('adopter');
+      }
+    }
+  }, [user?.role, userTypeFromUrl]);
+
+  // URL에서 faqId가 있으면 해당 FAQ를 열기
+  useEffect(() => {
+    if (faqs.length > 0 && faqIdFromUrl) {
+      const targetIndex = faqs.findIndex((faq) => faq.faqId === faqIdFromUrl);
+      if (targetIndex !== -1) {
+        setOpenIndex(targetIndex);
+        // 만약 10개 이상이면 더보기 버튼을 눌러야 보이므로 showAll을 true로 설정
+        if (targetIndex >= 10) {
+          setShowAll(true);
+        }
+      } else {
+        // FAQ를 찾지 못하면 첫 번째 아이템 열기
+        setOpenIndex(0);
+      }
+    } else if (faqs.length > 0) {
+      setOpenIndex(0); // 첫 번째 아이템 열기
+    }
+  }, [faqs, faqIdFromUrl]);
+
+  const handleToggle = (index: number) => {
+    setOpenIndex((prev) => {
+      // 이미 열려있는 항목을 클릭하면 변화 없음
+      if (prev === index) {
+        return prev;
+      }
+
+      return index;
+    });
+  };
+
+  const handleTabChange = (tab: TabType) => {
+    setActiveTab(tab);
+    setShowAll(false);
+  };
+
+  const displayedItems = showAll ? faqs : faqs.slice(0, 10);
+  const hasMore = faqs.length > 10;
+
+  // displayedItems의 인덱스를 실제 faqs 배열의 인덱스로 변환하는 헬퍼 함수
+  const getRealIndex = (item: FaqDto): number => {
+    return faqs.findIndex((faq) => faq.faqId === item.faqId);
+  };
+
+  const handleShowAll = () => {
+    setShowAll(true);
+  };
+
+  return {
+    activeTab,
+    openIndex,
+    showAll,
+    faqs,
+    displayedItems,
+    hasMore,
+    isLoading,
+    error,
+    handleToggle,
+    handleTabChange,
+    handleShowAll,
+    getRealIndex,
+  };
+}


### PR DESCRIPTION
### 작업 내용

## 홈 화면 FAQ 클릭 기능 추가
 `src/app/(main)/_components/faq.tsx` 
- 각 FAQ 아이템을 `Link` 컴포넌트로 감싸서 클릭 가능하게 변경
- URL 쿼리 파라미터로 `faqId`와 `userType` 전달
- 클릭 시 해당 질문이 열린 상태로 FAQ 페이지로 이동

## FAQ 페이지 로직 훅 분리
`src/app/(main)/faq/_hooks/use-faq-page.ts`
- `useFaqPage` 커스텀 훅 생성 
- 상태 관리 로직 (activeTab, openIndex, showAll) 훅으로 이동
- URL 파라미터 처리 로직 훅으로 이동
- FAQ 열기/닫기, 탭 변경, 더보기 로직 훅으로 이동



### 연관 이슈
#116 