### PR TITLE
feat : (브리더 회원가입) 서류 건너뛰기 멘트 추가 및 푸터 위치 수정

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -21,9 +21,11 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
   return (
     <Suspense>
       <NavigationGuardProvider>
-        {hasHydrated && <Gnb variant={useTertiaryVariant ? 'tertiary' : 'default'} navVariant={navVariant} />}
-        {children}
-        <Footer />
+        <div className="flex flex-col min-h-screen">
+          {hasHydrated && <Gnb variant={useTertiaryVariant ? 'tertiary' : 'default'} navVariant={navVariant} />}
+          <main className="flex-1">{children}</main>
+          <Footer />
+        </div>
       </NavigationGuardProvider>
     </Suspense>
   );

--- a/src/app/signup/_components/document-skip-dialog-trigger.tsx
+++ b/src/app/signup/_components/document-skip-dialog-trigger.tsx
@@ -21,8 +21,10 @@ interface DocumentSkipDialogTriggerProps extends React.ComponentProps<typeof Dia
 
 export default function DocumentSkipDialogTrigger({ onSkip, ...props }: DocumentSkipDialogTriggerProps) {
   const nextFlowIndex = useSignupFormStore((e) => e.nextFlowIndex);
+  const setDocumentsSkipped = useSignupFormStore((e) => e.setDocumentsSkipped);
 
   const handleSkip = async () => {
+    setDocumentsSkipped(true);
     if (onSkip) {
       await onSkip();
     } else {

--- a/src/app/signup/_components/sections/document-section.tsx
+++ b/src/app/signup/_components/sections/document-section.tsx
@@ -35,12 +35,7 @@ const levelInfo = [
     icon: Crown,
     label: 'Elite 엘리트',
     description: '엘리트 레벨은 전문성과 윤리적 기준을 증명해 차별화된 신뢰와 가치를 제공하는 상위 레벨이에요.',
-    documents: [
-      '신분증 사본',
-      '동물생산업 등록증',
-      '표준 입양계약서 샘플',
-      '고양이 브리더 인증 서류',
-    ],
+    documents: ['신분증 사본', '동물생산업 등록증', '표준 입양계약서 샘플', '고양이 브리더 인증 서류'],
   },
   {
     name: 'new',
@@ -53,6 +48,7 @@ const levelInfo = [
 
 export default function DocumentSection() {
   const router = useRouter();
+  const setDocumentsSkipped = useSignupFormStore((e) => e.setDocumentsSkipped);
   const level = useSignupFormStore((e) => e.level);
   const setLevel = useSignupFormStore((e) => e.setLevel);
   const nextFlowIndex = useSignupFormStore((e) => e.nextFlowIndex);
@@ -181,6 +177,9 @@ export default function DocumentSection() {
         }),
       });
 
+      // 서류 제출 완료 표시
+      setDocumentsSkipped(false);
+
       // 다음 단계 진행 (SignupComplete)
       nextFlowIndex();
     } catch (error) {
@@ -250,9 +249,7 @@ export default function DocumentSection() {
           <div className="space-y-3">
             <FileButton onUpload={handleFileUpload(DOCUMENT_TYPES.ANIMAL_LICENSE)}>동물생산업 등록증</FileButton>
             {level === 'elite' && (
-              <FileButton onUpload={handleFileUpload(DOCUMENT_TYPES.CONTRACT_SAMPLE)}>
-                표준 입양계약서 샘플
-              </FileButton>
+              <FileButton onUpload={handleFileUpload(DOCUMENT_TYPES.CONTRACT_SAMPLE)}>표준 입양계약서 샘플</FileButton>
             )}
           </div>
 

--- a/src/app/signup/_components/sections/signup-complete.tsx
+++ b/src/app/signup/_components/sections/signup-complete.tsx
@@ -1,31 +1,67 @@
+'use client';
+
 import SignupFormItems from '@/components/signup-form-section/signup-form-items';
 import SignupFormSection from '@/components/signup-form-section/signup-form-section';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
+import useSignupFormStore from '@/stores/signup-form-store';
 
 export default function SignupComplete() {
+  const documentsSkipped = useSignupFormStore((e) => e.documentsSkipped);
+  const userType = useSignupFormStore((e) => e.userType);
+
+  // 브리더이고 서류를 건너뛴 경우
+  const isBreederSkipped = userType === 'breeder' && documentsSkipped;
+
   return (
     <SignupFormSection className="gap-8 md:gap-8 lg:gap-8">
       <div className="w-full max-w-100 aspect-[4/3] bg-accent" />
       <div className="space-y-3 text-center">
-        <div className="text-balance text-body-m text-primary/80 font-medium">
-          포퐁에 오신 걸 환영해요!
-          <br /> 브리더 심사는 <span className="text-secondary-700">최대 3영업일</span> 정도 소요될 수 있어요.
-          <br />
-          제출한 서류를 변경하고 싶거나, <br />
-          궁금한 점이 있으면 고객센터로 문의해 주세요.
-        </div>
-        <div className="flex gap-2 text-sm leading-[140%] tracking-[-2%] justify-center">
-          <div>이메일 문의</div>
-          <a
-            className="text-secondary-700 underline"
-            href="mailto:pawriendsofficial@gmail.com"
-            target="_blank"
-            rel="noreferrer"
-          >
-            pawriendsofficial@gmail.com
-          </a>
-        </div>
+        {isBreederSkipped ? (
+          <>
+            <div className="text-balance text-body-m text-primary/80 font-medium">
+              포퐁에 오신 걸 환영해요!
+              <br />
+              미제출 서류는 <span className="text-secondary-700">&apos;마이&apos;</span>에서 추가로 제출하실 수 있어요.
+              <br />
+              심사는 서류 제출 완료 이후 최대 3영업일 정도 소요됩니다.
+              <br />
+              궁금한 점이 있으면 고객센터로 문의해 주세요.
+            </div>
+            <div className="flex gap-2 text-sm leading-[140%] tracking-[-2%] justify-center">
+              <div>이메일 문의</div>
+              <a
+                className="text-secondary-700 underline"
+                href="mailto:pawriendsofficial@gmail.com"
+                target="_blank"
+                rel="noreferrer"
+              >
+                pawriendsofficial@gmail.com
+              </a>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="text-balance text-body-m text-primary/80 font-medium">
+              포퐁에 오신 걸 환영해요!
+              <br /> 브리더 심사는 <span className="text-secondary-700">최대 3영업일</span> 정도 소요될 수 있어요.
+              <br />
+              제출한 서류를 변경하고 싶거나, <br />
+              궁금한 점이 있으면 고객센터로 문의해 주세요.
+            </div>
+            <div className="flex gap-2 text-sm leading-[140%] tracking-[-2%] justify-center">
+              <div>이메일 문의</div>
+              <a
+                className="text-secondary-700 underline"
+                href="mailto:pawriendsofficial@gmail.com"
+                target="_blank"
+                rel="noreferrer"
+              >
+                pawriendsofficial@gmail.com
+              </a>
+            </div>
+          </>
+        )}
       </div>
       <SignupFormItems className="flex flex-col gap-3">
         <Link href="/">

--- a/src/stores/signup-form-store.ts
+++ b/src/stores/signup-form-store.ts
@@ -75,6 +75,9 @@ interface SignupFormStore {
   documents: Record<string, File | null>;
   setDocuments: (name: string, file: File | null) => void;
   resetFlowIndex: () => void;
+
+  documentsSkipped: boolean;
+  setDocumentsSkipped: (skipped: boolean) => void;
 }
 
 const useSignupFormStore = create<SignupFormStore>((set) => ({
@@ -156,6 +159,9 @@ const useSignupFormStore = create<SignupFormStore>((set) => ({
       documents: { ...state.documents, [name]: file },
     })),
   resetFlowIndex: () => set({ flowIndex: 0 }),
+
+  documentsSkipped: false,
+  setDocumentsSkipped: (skipped: boolean) => set({ documentsSkipped: skipped }),
 }));
 
 export default useSignupFormStore;


### PR DESCRIPTION
### 작업 내용


## 구현 내용

## 푸터 하단 고정
- 레이아웃을 `flex flex-col min-h-screen` 구조로 변경
- 메인 콘텐츠 영역을 `flex-1`로 설정하여 남은 공간을 채우도록 함
- 푸터가 항상 화면 최하단에 위치하도록 개선


## 브리더 회원가입 서류 건너뛰기 멘트 개선
- `signup-form-store`에 `documentsSkipped` 추가
- 서류 제출 단계에서 "나중에 할래요" 선택 시 `documentsSkipped`를 `true`로 설정
- 서류 제출 완료 시 `documentsSkipped`를 `false`로 설정
- `SignupComplete` 컴포넌트에서 브리더이고 서류를 건너뛴 경우 별도 멘트 표시:


### 연관 이슈
#116 
