### PR TITLE
feat : (브리더 프로필) 엄마아빠 페이지 추가

### DIFF
--- a/src/app/(main)/explore/breeder/[id]/_components/parents.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/parents.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
 import BreederProfileSection from '@/components/breeder-profile/breeder-profile-section';
 import BreederProfileSectionHeader from '@/components/breeder-profile/breeder-profile-section-header';
 import BreederProfileSectionMore from '@/components/breeder-profile/breeder-profile-section-more';
@@ -6,6 +9,7 @@ import AnimalProfile from './animal-profile';
 
 export default function Parents({
   data,
+  breederId,
 }: {
   data: {
     id: string;
@@ -16,27 +20,40 @@ export default function Parents({
     price: string;
     breed: string;
   }[];
+  breederId: string;
 }) {
+  const router = useRouter();
+
+  const handleMoreClick = () => {
+    router.push(`/explore/breeder/${breederId}/parents`);
+  };
+
   return (
     <BreederProfileSection>
       <BreederProfileSectionHeader>
         <BreederProfileSectionTitle>엄마 · 아빠</BreederProfileSectionTitle>
-        {data.length > 3 && <BreederProfileSectionMore />}
+        {data.length > 1 ? (
+          <div onClick={handleMoreClick}>
+            <BreederProfileSectionMore />
+          </div>
+        ) : null}
       </BreederProfileSectionHeader>
       <div className="space-y-7 md:grid md:grid-cols-3 md:gap-gutter">
-        {data.map(
-          (e: {
-            id: string;
-            avatarUrl: string;
-            name: string;
-            sex: 'male' | 'female';
-            birth: string;
-            price: string;
-            breed: string;
-          }) => (
-            <AnimalProfile key={e.id} data={e} />
-          ),
-        )}
+        {data
+          .slice(0, 3)
+          .map(
+            (e: {
+              id: string;
+              avatarUrl: string;
+              name: string;
+              sex: 'male' | 'female';
+              birth: string;
+              price: string;
+              breed: string;
+            }) => (
+              <AnimalProfile key={e.id} data={e} />
+            ),
+          )}
       </div>
     </BreederProfileSection>
   );

--- a/src/app/(main)/explore/breeder/[id]/_hooks/use-breeder-detail.ts
+++ b/src/app/(main)/explore/breeder/[id]/_hooks/use-breeder-detail.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
 import { getBreederProfile, getBreederPets, getParentPets, getBreederReviews } from '@/lib/breeder';
 
 /**
@@ -29,12 +29,28 @@ export function useBreederPets(breederId: string, page: number = 1, limit: numbe
 }
 
 /**
- * 브리더 부모견/부모묘 목록 조회 훅
+ * 브리더 부모견/부모묘 목록 조회 훅 (페이지네이션)
  */
-export function useParentPets(breederId: string) {
+export function useParentPets(breederId: string, page: number = 1, limit: number = 4) {
   return useQuery({
-    queryKey: ['parent-pets', breederId],
-    queryFn: () => getParentPets(breederId),
+    queryKey: ['parent-pets', breederId, page, limit],
+    queryFn: () => getParentPets(breederId, page, limit),
+    enabled: !!breederId,
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+/**
+ * 브리더 부모견/부모묘 목록 조회 훅 (무한 스크롤)
+ */
+export function useParentPetsInfinite(breederId: string, limit: number = 4) {
+  return useInfiniteQuery({
+    queryKey: ['parent-pets-infinite', breederId, limit],
+    queryFn: ({ pageParam = 1 }) => getParentPets(breederId, pageParam, limit),
+    getNextPageParam: (lastPage) => {
+      return lastPage.pagination?.hasNextPage ? lastPage.pagination.currentPage + 1 : undefined;
+    },
+    initialPageParam: 1,
     enabled: !!breederId,
     staleTime: 1000 * 60 * 5,
   });

--- a/src/app/(main)/explore/breeder/[id]/page.tsx
+++ b/src/app/(main)/explore/breeder/[id]/page.tsx
@@ -43,7 +43,7 @@ export default function Page({ params }: PageProps) {
 
   const { data: profileData, isLoading: isProfileLoading, error: profileError } = useBreederProfile(breederId);
   const { data: petsData, isLoading: isPetsLoading } = useBreederPets(breederId);
-  const { data: parentPetsData, isLoading: isParentPetsLoading } = useParentPets(breederId);
+  const { data: parentPetsData, isLoading: isParentPetsLoading } = useParentPets(breederId, 1, 100);
   const { data: reviewsData, isLoading: isReviewsLoading } = useBreederReviews(breederId);
 
   // 탈퇴한 브리더 모달 상태
@@ -121,8 +121,8 @@ export default function Page({ params }: PageProps) {
                 {isNotFoundError
                   ? '브리더 정보가 존재하지 않거나\n접근할 수 없어요.'
                   : isOwnProfile
-                    ? '탈퇴 처리된 계정이에요.\n다시 로그인해 주세요.'
-                    : '이미 탈퇴한 브리더의 프로필은\n조회할 수 없어요.'}
+                  ? '탈퇴 처리된 계정이에요.\n다시 로그인해 주세요.'
+                  : '이미 탈퇴한 브리더의 프로필은\n조회할 수 없어요.'}
               </SimpleDialogDescription>
             </SimpleDialogHeader>
             <SimpleDialogFooter className="grid-cols-1">
@@ -206,8 +206,8 @@ export default function Page({ params }: PageProps) {
     breed: pet.breed,
   }));
 
-  // 부모견/부모묘 매핑 - 배열 또는 객체 형태 모두 처리
-  const parentPetsArray = Array.isArray(parentPetsData) ? parentPetsData : (parentPetsData as any)?.items || [];
+  // 부모견/부모묘 매핑 - 페이지네이션 응답 형태 처리
+  const parentPetsArray = parentPetsData?.items || [];
   const parentPets = parentPetsArray.map((pet: any) => ({
     id: pet.petId,
     avatarUrl: pet.photoUrl || '/animal-sample.png',
@@ -275,7 +275,7 @@ export default function Page({ params }: PageProps) {
 
           {!isParentPetsLoading && parentPets.length > 0 && (
             <>
-              <Parents data={parentPets} />
+              <Parents data={parentPets} breederId={breederId} />
               <Separator className="my-12" />
             </>
           )}

--- a/src/app/(main)/explore/breeder/[id]/parents/page.tsx
+++ b/src/app/(main)/explore/breeder/[id]/parents/page.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { use } from 'react';
+import Header from '../../_components/header';
+import AnimalProfile from '../_components/animal-profile';
+import { useBreederProfile, useParentPetsInfinite } from '../_hooks/use-breeder-detail';
+import { Button } from '@/components/ui/button';
+import DownArrow from '@/assets/icons/long-down-arrow.svg';
+
+interface PageProps {
+  params: Promise<{
+    id: string;
+  }>;
+}
+
+export default function ParentsPage({ params }: PageProps) {
+  const { id: breederId } = use(params);
+  const { data: profileData } = useBreederProfile(breederId);
+  const {
+    data: parentPetsData,
+    isLoading: isParentPetsLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useParentPetsInfinite(breederId, 10);
+
+  // 날짜 포맷팅 함수 (브리더 상세 페이지와 동일)
+  const formatBirthDate = (dateString: string | Date | undefined) => {
+    if (!dateString) return '';
+    try {
+      const date = new Date(dateString);
+      if (isNaN(date.getTime())) return '';
+      const year = date.getFullYear();
+      const month = date.getMonth() + 1;
+      const day = date.getDate();
+      return `${year}년 ${month}월 ${day}일 생`;
+    } catch {
+      return '';
+    }
+  };
+
+  // 부모견/부모묘 매핑 - 모든 페이지의 데이터를 합침
+  type ParentPet = {
+    petId: string;
+    photoUrl?: string;
+    name: string;
+    gender: 'male' | 'female';
+    birthDate?: string;
+    breed: string;
+  };
+
+  type MappedParentPet = {
+    id: string;
+    avatarUrl: string;
+    name: string;
+    sex: 'male' | 'female';
+    birth: string;
+    price: string;
+    breed: string;
+  };
+
+  // 모든 페이지의 데이터를 합쳐서 매핑
+  const allParentPets: MappedParentPet[] =
+    parentPetsData?.pages
+      .flatMap((page) => page.items || [])
+      .map((pet: ParentPet) => ({
+        id: pet.petId,
+        avatarUrl: pet.photoUrl || '/animal-sample.png',
+        name: pet.name,
+        sex: pet.gender,
+        birth: formatBirthDate(pet.birthDate),
+        price: '', // 부모견은 가격이 없음
+        breed: pet.breed,
+      })) || [];
+
+  // 첫 페이지의 총 개수 확인 (더보기 버튼 표시 여부 결정용)
+  const firstPageCount = parentPetsData?.pages[0]?.items?.length || 0;
+
+  return (
+    <>
+      <Header breederNickname={profileData?.breederName || ''} breederId={breederId} hideActions />
+      <div className="pt-4 pb-20">
+        <div className="flex flex-col items-center gap-10">
+          {/* 헤더 */}
+          <div className="w-full flex">
+            <h1 className="text-heading-3 font-semibold text-primary text-center">엄마 · 아빠</h1>
+          </div>
+
+          {/* 콘텐츠 */}
+          {isParentPetsLoading ? (
+            <div className="flex items-center justify-center py-20">
+              <p className="text-body-s text-grayscale-gray5">로딩 중...</p>
+            </div>
+          ) : allParentPets.length === 0 ? (
+            <div className="flex items-center justify-center py-20">
+              <p className="text-body-s text-grayscale-gray5">등록된 엄마 · 아빠가 없습니다.</p>
+            </div>
+          ) : (
+            <div className="w-full flex flex-col items-center gap-10 md:gap-[60px] lg:gap-20">
+              <div className="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+                {allParentPets.map((parent) => (
+                  <AnimalProfile key={parent.id} data={parent} />
+                ))}
+              </div>
+              {/* 더보기 버튼 - 첫 페이지가 10개 이상이고 다음 페이지가 있을 때만 표시 */}
+              {firstPageCount >= 10 && hasNextPage && (
+                <div className="flex justify-center">
+                  <Button
+                    variant="ghost"
+                    onClick={() => fetchNextPage()}
+                    disabled={isFetchingNextPage}
+                    className="bg-[var(--color-grayscale-gray1)] hover:bg-[var(--color-grayscale-gray2)] h-12 py-2.5 gap-1 rounded-full has-[>svg]:px-0 has-[>svg]:pl-5 has-[>svg]:pr-3 disabled:opacity-50"
+                  >
+                    <span className="text-body-s font-medium text-grayscale-gray6">
+                      {isFetchingNextPage ? '로딩 중...' : '더보기'}
+                    </span>
+                    <DownArrow />
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/(main)/explore/breeder/_components/header.tsx
+++ b/src/app/(main)/explore/breeder/_components/header.tsx
@@ -14,9 +14,10 @@ import type { FavoriteItemDto } from '@/lib/adopter';
 interface HeaderProps {
   breederNickname: string;
   breederId: string;
+  hideActions?: boolean;
 }
 
-export default function Header({ breederNickname, breederId }: HeaderProps) {
+export default function Header({ breederNickname, breederId, hideActions = false }: HeaderProps) {
   const router = useRouter();
   const [isReportDialogOpen, setIsReportDialogOpen] = useState(false);
   const { toggle, isLoading } = useToggleFavorite();
@@ -46,18 +47,20 @@ export default function Header({ breederNickname, breederId }: HeaderProps) {
         <Button variant="secondary" size="icon" className="size-9" onClick={handleBack}>
           <ArrowRight className="size-7" />
         </Button>
-        <div className="flex gap-3">
-          <Button variant="secondary" size="icon" className="size-9" onClick={() => setIsReportDialogOpen(true)}>
-            <Siren className="size-7" />
-          </Button>
-          <Button variant="secondary" size="icon" className="size-9" onClick={handleLikeClick} disabled={isLoading}>
-            {isLiked ? (
-              <HeartGray className="size-7" style={{ shapeRendering: 'crispEdges' }} />
-            ) : (
-              <Paw className="size-7" />
-            )}
-          </Button>
-        </div>
+        {!hideActions && (
+          <div className="flex gap-3">
+            <Button variant="secondary" size="icon" className="size-9" onClick={() => setIsReportDialogOpen(true)}>
+              <Siren className="size-7" />
+            </Button>
+            <Button variant="secondary" size="icon" className="size-9" onClick={handleLikeClick} disabled={isLoading}>
+              {isLiked ? (
+                <HeartGray className="size-7" style={{ shapeRendering: 'crispEdges' }} />
+              ) : (
+                <Paw className="size-7" />
+              )}
+            </Button>
+          </div>
+        )}
       </div>
       <ReportDialog
         open={isReportDialogOpen}

--- a/src/app/(main)/profile/_components/parents-info.tsx
+++ b/src/app/(main)/profile/_components/parents-info.tsx
@@ -46,7 +46,7 @@ export default function ParentsInfo({ form }: { form: ReturnType<typeof useFormC
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const MAX_PARENTS = 4;
+  const MAX_PARENTS = 100; // 충분히 큰 값으로 설정하여 제한 없음
 
   const addParent = () => {
     if (fields.length >= MAX_PARENTS) return;
@@ -182,8 +182,8 @@ export default function ParentsInfo({ form }: { form: ReturnType<typeof useFormC
                         !parent.gender && errors.parents?.[index]?.gender
                           ? '[&_path]:!fill-red-500'
                           : parent.gender === 'male'
-                            ? '[&_path]:fill-gender-male-500 group-hover:[&_path]:fill-gender-male-500'
-                            : 'group-hover:[&_path]:fill-gender-male-500',
+                          ? '[&_path]:fill-gender-male-500 group-hover:[&_path]:fill-gender-male-500'
+                          : 'group-hover:[&_path]:fill-gender-male-500',
                       )}
                     />
                   </Button>
@@ -206,8 +206,8 @@ export default function ParentsInfo({ form }: { form: ReturnType<typeof useFormC
                         !parent.gender && errors.parents?.[index]?.gender
                           ? '[&_path]:!fill-red-500'
                           : parent.gender === 'female'
-                            ? '[&_path]:fill-gender-female-500 group-hover:[&_path]:fill-gender-female-500'
-                            : 'group-hover:[&_path]:fill-gender-female-500',
+                          ? '[&_path]:fill-gender-female-500 group-hover:[&_path]:fill-gender-female-500'
+                          : 'group-hover:[&_path]:fill-gender-female-500',
                       )}
                     />
                   </Button>

--- a/src/components/breeder-profile/breeder-profile-section-more.tsx
+++ b/src/components/breeder-profile/breeder-profile-section-more.tsx
@@ -3,7 +3,7 @@ import { Button } from '../ui/button';
 
 export default function BreederProfileSectionMore() {
   return (
-    <Button variant="ghost" className="gap-1 p-0 text-grayscale-gray5 text-body-xs">
+    <Button type="button" variant="ghost" className="gap-1 p-0 text-grayscale-gray5 text-body-xs">
       <div>더보기</div>
       <ChevronRight className="size-3.5" />
     </Button>

--- a/src/lib/breeder.ts
+++ b/src/lib/breeder.ts
@@ -401,10 +401,9 @@ export const getBreederPets = async (
   limit: number = 20,
 ): Promise<{ items: any[]; pagination: any }> => {
   try {
-    const response = await apiClient.get<ApiResponse<PaginationResponse<any>>>(
-      `/api/breeder/${breederId}/pets`,
-      { params: { page, limit } },
-    );
+    const response = await apiClient.get<ApiResponse<PaginationResponse<any>>>(`/api/breeder/${breederId}/pets`, {
+      params: { page, limit },
+    });
 
     if (!response.data.success || !response.data.data) {
       throw new Error('Failed to fetch breeder pets');
@@ -424,9 +423,16 @@ export const getBreederPets = async (
  * 브리더 부모견/부모묘 목록 조회
  * GET /api/breeder/:breederId/parent-pets
  */
-export const getParentPets = async (breederId: string): Promise<any[]> => {
+export const getParentPets = async (
+  breederId: string,
+  page: number = 1,
+  limit: number = 4,
+): Promise<{ items: any[]; pagination: any }> => {
   try {
-    const response = await apiClient.get<ApiResponse<any[]>>(`/api/breeder/${breederId}/parent-pets`);
+    const response = await apiClient.get<ApiResponse<PaginationResponse<any>>>(
+      `/api/breeder/${breederId}/parent-pets`,
+      { params: { page, limit } },
+    );
 
     if (!response.data.success || !response.data.data) {
       throw new Error('Failed to fetch parent pets');
@@ -452,10 +458,9 @@ export const getBreederReviews = async (
   limit: number = 10,
 ): Promise<{ items: any[]; pagination: any }> => {
   try {
-    const response = await apiClient.get<ApiResponse<PaginationResponse<any>>>(
-      `/api/breeder/${breederId}/reviews`,
-      { params: { page, limit } },
-    );
+    const response = await apiClient.get<ApiResponse<PaginationResponse<any>>>(`/api/breeder/${breederId}/reviews`, {
+      params: { page, limit },
+    });
 
     if (!response.data.success || !response.data.data) {
       throw new Error('Failed to fetch breeder reviews');
@@ -472,7 +477,11 @@ export const getBreederReviews = async (
 };
 
 /** 입양 신청 상태 타입 */
-export type ApplicationStatus = 'consultation_pending' | 'consultation_completed' | 'adoption_approved' | 'adoption_rejected';
+export type ApplicationStatus =
+  | 'consultation_pending'
+  | 'consultation_completed'
+  | 'adoption_approved'
+  | 'adoption_rejected';
 
 /** 입양 신청 상태 업데이트 요청 DTO */
 export interface ApplicationStatusUpdateRequestDto {


### PR DESCRIPTION
### 작업 내용

## 엄마아빠 페이지 페이지네이션 구현
- `useInfiniteQuery`를 사용한 무한 스크롤 방식의 페이지네이션 추가
- 10개 이상일 때만 더보기 버튼 표시
- 더보기 버튼 클릭 시 다음 페이지 자동 로드


## API 함수 페이지네이션 지원
- `getParentPets` 함수에 `page`, `limit` 파라미터 추가
- 페이지네이션 응답 형태로 변경 (`{ items, pagination }`)

## (임시) 브리더 프로필 엄마아빠 추가 제한 해제
- 엄마아빠 추가 제한을 4개에서 100개로 변경


### 연관 이슈
#155 
