### PR TITLE
feat :(브리더 프로필) 분양중인 아이들 페이지 추가

### DIFF
--- a/src/app/(main)/explore/breeder/[id]/_components/breeding-animals.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/breeding-animals.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
 import BreederProfileSection from '@/components/breeder-profile/breeder-profile-section';
 import BreederProfileSectionHeader from '@/components/breeder-profile/breeder-profile-section-header';
 import BreederProfileSectionMore from '@/components/breeder-profile/breeder-profile-section-more';
@@ -6,6 +9,7 @@ import AnimalProfile from './animal-profile';
 
 export default function BreedingAnimals({
   data,
+  breederId,
 }: {
   data: {
     id: string;
@@ -16,27 +20,40 @@ export default function BreedingAnimals({
     price: string | null;
     breed: string;
   }[];
+  breederId: string;
 }) {
+  const router = useRouter();
+
+  const handleMoreClick = () => {
+    router.push(`/explore/breeder/${breederId}/pets`);
+  };
+
   return (
     <BreederProfileSection>
       <BreederProfileSectionHeader>
         <BreederProfileSectionTitle>분양 중인 아이들</BreederProfileSectionTitle>
-        {data.length > 3 && <BreederProfileSectionMore />}
+        {data.length > 3 ? (
+          <div onClick={handleMoreClick}>
+            <BreederProfileSectionMore />
+          </div>
+        ) : null}
       </BreederProfileSectionHeader>
       <div className="space-y-7 md:grid md:grid-cols-3 md:gap-gutter">
-        {data.map(
-          (e: {
-            id: string;
-            avatarUrl: string;
-            name: string;
-            sex: 'male' | 'female';
-            birth: string;
-            price: string | null;
-            breed: string;
-          }) => (
-            <AnimalProfile key={e.id} data={e} />
-          ),
-        )}
+        {data
+          .slice(0, 3)
+          .map(
+            (e: {
+              id: string;
+              avatarUrl: string;
+              name: string;
+              sex: 'male' | 'female';
+              birth: string;
+              price: string | null;
+              breed: string;
+            }) => (
+              <AnimalProfile key={e.id} data={e} />
+            ),
+          )}
       </div>
     </BreederProfileSection>
   );

--- a/src/app/(main)/explore/breeder/[id]/_hooks/use-breeder-detail.ts
+++ b/src/app/(main)/explore/breeder/[id]/_hooks/use-breeder-detail.ts
@@ -29,6 +29,22 @@ export function useBreederPets(breederId: string, page: number = 1, limit: numbe
 }
 
 /**
+ * 브리더 분양 가능 개체 목록 조회 훅 (무한 스크롤)
+ */
+export function useBreederPetsInfinite(breederId: string, limit: number = 10) {
+  return useInfiniteQuery({
+    queryKey: ['breeder-pets-infinite', breederId, limit],
+    queryFn: ({ pageParam = 1 }) => getBreederPets(breederId, pageParam, limit),
+    getNextPageParam: (lastPage) => {
+      return lastPage.pagination?.hasNextPage ? lastPage.pagination.currentPage + 1 : undefined;
+    },
+    initialPageParam: 1,
+    enabled: !!breederId,
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+/**
  * 브리더 부모견/부모묘 목록 조회 훅 (페이지네이션)
  */
 export function useParentPets(breederId: string, page: number = 1, limit: number = 4) {

--- a/src/app/(main)/explore/breeder/[id]/page.tsx
+++ b/src/app/(main)/explore/breeder/[id]/page.tsx
@@ -268,7 +268,7 @@ export default function Page({ params }: PageProps) {
 
           {!isPetsLoading && breedingAnimals.length > 0 && (
             <>
-              <BreedingAnimals data={breedingAnimals} />
+              <BreedingAnimals data={breedingAnimals} breederId={breederId} />
               <Separator className="my-12" />
             </>
           )}

--- a/src/app/(main)/explore/breeder/[id]/pets/page.tsx
+++ b/src/app/(main)/explore/breeder/[id]/pets/page.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { use } from 'react';
+import Header from '../../_components/header';
+import AnimalProfile from '../_components/animal-profile';
+import { useBreederProfile, useBreederPetsInfinite } from '../_hooks/use-breeder-detail';
+import { Button } from '@/components/ui/button';
+import DownArrow from '@/assets/icons/long-down-arrow.svg';
+import { useAuthStore } from '@/stores/auth-store';
+
+interface PageProps {
+  params: Promise<{
+    id: string;
+  }>;
+}
+
+export default function PetsPage({ params }: PageProps) {
+  const { id: breederId } = use(params);
+  const { user } = useAuthStore();
+  const { data: profileData } = useBreederProfile(breederId);
+  const {
+    data: petsData,
+    isLoading: isPetsLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useBreederPetsInfinite(breederId, 10);
+
+  // 날짜 포맷팅 함수 (브리더 상세 페이지와 동일)
+  const formatBirthDate = (dateString: string | Date | undefined) => {
+    if (!dateString) return '';
+    try {
+      const date = new Date(dateString);
+      if (isNaN(date.getTime())) return '';
+      const year = date.getFullYear();
+      const month = date.getMonth() + 1;
+      const day = date.getDate();
+      return `${year}년 ${month}월 ${day}일 생`;
+    } catch {
+      return '';
+    }
+  };
+
+  // 분양 가능 개체 매핑 - 모든 페이지의 데이터를 합침
+  type Pet = {
+    petId: string;
+    mainPhoto?: string;
+    name: string;
+    gender: 'male' | 'female';
+    birthDate?: string;
+    price?: number;
+    breed: string;
+  };
+
+  type MappedPet = {
+    id: string;
+    avatarUrl: string;
+    name: string;
+    sex: 'male' | 'female';
+    birth: string;
+    price: string | null;
+    breed: string;
+  };
+
+  // 모든 페이지의 데이터를 합쳐서 매핑
+  const allPets: MappedPet[] =
+    petsData?.pages
+      .flatMap((page) => page.items || [])
+      .map((pet: Pet) => ({
+        id: pet.petId,
+        avatarUrl: pet.mainPhoto || '/animal-sample.png',
+        name: pet.name,
+        sex: pet.gender,
+        birth: formatBirthDate(pet.birthDate),
+        price: user ? `${pet.price?.toLocaleString() || 0}원` : null,
+        breed: pet.breed,
+      })) || [];
+
+  // 첫 페이지의 총 개수 확인 (더보기 버튼 표시 여부 결정용)
+  const firstPageCount = petsData?.pages[0]?.items?.length || 0;
+
+  return (
+    <>
+      <Header breederNickname={profileData?.breederName || ''} breederId={breederId} hideActions />
+      <div className="pt-4 pb-20">
+        <div className="flex flex-col items-center gap-10">
+          {/* 헤더 */}
+          <div className="w-full flex">
+            <h1 className="text-heading-3 font-semibold text-primary text-center">분양 중인 아이들</h1>
+          </div>
+
+          {/* 콘텐츠 */}
+          {isPetsLoading ? (
+            <div className="flex items-center justify-center py-20">
+              <p className="text-body-s text-grayscale-gray5">로딩 중...</p>
+            </div>
+          ) : allPets.length === 0 ? (
+            <div className="flex items-center justify-center py-20">
+              <p className="text-body-s text-grayscale-gray5">등록된 분양 중인 아이들이 없습니다.</p>
+            </div>
+          ) : (
+            <div className="w-full flex flex-col items-center gap-10 md:gap-[60px] lg:gap-20">
+              <div className="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+                {allPets.map((pet) => (
+                  <AnimalProfile key={pet.id} data={pet} />
+                ))}
+              </div>
+              {/* 더보기 버튼 - 첫 페이지가 10개 이상이고 다음 페이지가 있을 때만 표시 */}
+              {firstPageCount >= 10 && hasNextPage && (
+                <div className="flex justify-center">
+                  <Button
+                    variant="ghost"
+                    onClick={() => fetchNextPage()}
+                    disabled={isFetchingNextPage}
+                    className="bg-[var(--color-grayscale-gray1)] hover:bg-[var(--color-grayscale-gray2)] h-12 py-2.5 gap-1 rounded-full has-[>svg]:px-0 has-[>svg]:pl-5 has-[>svg]:pr-3 disabled:opacity-50"
+                  >
+                    <span className="text-body-s font-medium text-grayscale-gray6">
+                      {isFetchingNextPage ? '로딩 중...' : '더보기'}
+                    </span>
+                    <DownArrow />
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
### 작업 내용


## 분양중인 아이들 페이지 페이지네이션 구현
- `useBreederPetsInfinite` 훅을 사용한 무한 스크롤 방식의 페이지네이션 추가
- 10개 이상일 때만 더보기 버튼 표시





### 연관 이슈
#155