### PR TITLE
feat : (브리더 회원가입) 서류 미제출 시 제출 버튼 비활성화 처리

### DIFF
--- a/src/app/signup/_components/sections/document-section.tsx
+++ b/src/app/signup/_components/sections/document-section.tsx
@@ -75,6 +75,14 @@ export default function DocumentSection() {
   const [uploading, setUploading] = useState(false);
   const { toast } = useToast();
 
+  // 레벨별 필수 서류 개수
+  const getRequiredDocumentCount = () => {
+    return level === 'elite' ? 4 : 2; // elite: 4개, new: 2개
+  };
+
+  // 서류가 모두 업로드되었는지 확인
+  const hasAllRequiredDocuments = uploadedFiles.length >= getRequiredDocumentCount();
+
   // 파일 업로드 핸들러 - 파일을 복제하여 저장 (ERR_UPLOAD_FILE_CHANGED 방지)
   const handleFileUpload = (type: string) => async (file: File) => {
     try {
@@ -326,7 +334,7 @@ export default function DocumentSection() {
             variant={'tertiary'}
             className="py-3 px-4 w-full flex-1"
             onClick={handleSubmit}
-            disabled={submitting || !check}
+            disabled={submitting || !check || !hasAllRequiredDocuments}
           >
             {uploading ? '서류 업로드 중...' : submitting ? '회원가입 중...' : '제출'}
           </Button>


### PR DESCRIPTION
### 작업 내용
## 서류 미제출 시 제출 버튼 비활성화 처리
- 레벨별 필수 서류 개수 확인 함수 추가 (`getRequiredDocumentCount`)
  - 엘리트 레벨: 4개 (신분증 사본, 동물생산업 등록증, 표준 입양계약서 샘플, 고양이 브리더 인증 서류)
  - 뉴 레벨: 2개 (신분증 사본, 동물생산업 등록증)
- 필수 서류 업로드 여부 확인 로직 추가 (`hasAllRequiredDocuments`)
- 제출 버튼 비활성화 조건에 서류 업로드 여부 추가
  - 기존: `disabled={submitting || !check}` (서약서 동의만 확인)
  - 변경: `disabled={submitting || !check || !hasAllRequiredDocuments}` (서약서 동의 + 필수 서류 모두 업로드 확인)




### 연관 이슈
#116