### PR TITLE
fix : (브리더 회원가입) 서류 미제출 시 경고 메시지 표시로 변경

### DIFF
--- a/src/constants/document.ts
+++ b/src/constants/document.ts
@@ -1,0 +1,15 @@
+// 서류 미제출 경고 메시지
+export const DOCUMENT_ERROR_MESSAGES = {
+  BREEDER_CERT: '해당되는 서류를 하나 골라 첨부해 주세요',
+  REQUIRED_DOCUMENTS: '필수 서류를 제출해주세요',
+  FILE_SIZE_LIMIT: '파일은 최대 10MB까지 업로드할 수 있어요',
+} as const;
+
+// 브리더 인증 서류 안내 텍스트
+export const BREEDER_CERT_INFO = {
+  cat: [
+    'TICA 또는 CFA 등록 확인서 (브리더 회원증/캐터리 등록증)',
+    '캣쇼 참가 증빙 자료 (참가 확인증, 수상 기록, 공식 프로그램 또는 카탈로그에 게재된 기록 등)',
+  ],
+  dog: ['애견연맹견사호등록증', '도그쇼 참가 증빙 자료(참가 확인증, 수상 기록, 공식 프로그램 등에 게재된 기록 등)'],
+} as const;


### PR DESCRIPTION
### 작업 내용

## 필수 서류 검증 로직 추가
- 신분증 사본: 필수 (미제출 시 "필수 서류를 제출해주세요" 경고)
- 브리더 인증 서류 (엘리트 레벨): 필수

## 브리더 인증 서류 안내 텍스트 개선
- 미제출 + 제출 시도 시: 빨간색(text-status-error-500) + 느낌표 아이콘 표시
- 고양이/강아지별 안내 텍스트 분리
  - 고양이: TICA/CFA 등록 확인서, 캣쇼 참가 증빙 자료
  - 강아지: 애견연맹견사호등록증, 도그쇼 참가 증빙 자료
## 상수 파일 분리
`src/constants/document.ts `
- DOCUMENT_ERROR_MESSAGES: 서류 미제출 경고 메시지
- BREEDER_CERT_INFO: 브리더 인증 서류 안내 텍스트

### 연관 이슈
#116 