### PR TITLE
fix: (닉네임) 중복검사 에러 처리 개선 및 제출 버튼 활성화 로직 수정

### DIFF
--- a/src/app/(main)/settings/_components/nickname-edit-dialog.tsx
+++ b/src/app/(main)/settings/_components/nickname-edit-dialog.tsx
@@ -73,7 +73,6 @@ export default function NicknameEditDialog({ open, onOpenChange, currentNickname
       const isDuplicate = await checkNicknameDuplicate(nickname);
       if (isDuplicate) {
         setNicknameAvailable(false);
-        alert('이미 사용 중인 닉네임입니다. 다른 닉네임을 입력해주세요.');
         return;
       }
 
@@ -84,7 +83,7 @@ export default function NicknameEditDialog({ open, onOpenChange, currentNickname
       setNicknameAvailable(null);
     } catch (error) {
       console.error('닉네임 중복 확인 오류:', error);
-      alert('닉네임 중복 확인에 실패했습니다.');
+      setNicknameAvailable(false);
     } finally {
       setIsSaving(false);
     }

--- a/src/app/signup/_components/sections/nickname-section.tsx
+++ b/src/app/signup/_components/sections/nickname-section.tsx
@@ -13,6 +13,7 @@ import useSignupFormStore from '@/stores/signup-form-store';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import Check from '@/assets/icons/check-blue.svg';
+import ErrorIcon from '@/assets/icons/error';
 
 export default function NicknameSection() {
   const router = useRouter();
@@ -32,6 +33,7 @@ export default function NicknameSection() {
   const [nicknameAvailable, setNicknameAvailable] = useState(false);
   const [checkingNickname, setCheckingNickname] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [submitAttempted, setSubmitAttempted] = useState(false);
 
   const isSocialLogin = !!tempId;
 
@@ -57,14 +59,8 @@ export default function NicknameSection() {
 
     try {
       const isDuplicate = await checkNicknameDuplicate(nickname);
-      if (isDuplicate) {
-        alert('이미 사용 중인 닉네임입니다. 다른 닉네임을 입력해주세요.');
-        setNicknameChecked(false);
-        setNicknameAvailable(false);
-      } else {
-        setNicknameChecked(true);
-        setNicknameAvailable(true);
-      }
+      setNicknameChecked(true);
+      setNicknameAvailable(!isDuplicate);
     } catch (error) {
       alert('닉네임 중복 확인에 실패했습니다.');
       setNicknameChecked(false);
@@ -79,12 +75,14 @@ export default function NicknameSection() {
     setNickname(value);
     setNicknameChecked(false);
     setNicknameAvailable(false);
+    setSubmitAttempted(false);
   };
 
   // Complete registration
   const handleSubmit = async () => {
+    setSubmitAttempted(true);
+
     if (!nicknameChecked || !nicknameAvailable) {
-      alert('닉네임 중복 확인을 완료해주세요.');
       return;
     }
 
@@ -182,15 +180,27 @@ export default function NicknameSection() {
               {checkingNickname ? '확인 중...' : '중복 검사'}
             </Button>
           </div>
-          {nicknameAvailable && (
+          {nicknameChecked && nicknameAvailable && (
             <div className="flex items-center gap-0.5">
               <Check className="size-3 shrink-0" />
               <p className="text-caption font-medium text-status-success-500">사용할 수 있는 닉네임이에요</p>
             </div>
           )}
+          {nicknameChecked && !nicknameAvailable && (
+            <div className="flex items-center gap-[0.19rem]">
+              <ErrorIcon className="size-3 shrink-0" />
+              <p className="text-caption font-medium text-status-error-500">이미 사용 중인 닉네임이에요</p>
+            </div>
+          )}
+          {submitAttempted && !nicknameChecked && (
+            <div className="flex items-center gap-[0.19rem]">
+              <ErrorIcon className="size-3 shrink-0" />
+              <p className="text-caption font-medium text-status-error-500">닉네임 중복 검사를 진행해 주세요</p>
+            </div>
+          )}
         </div>
         <div className="flex flex-col gap-4">
-          <NextButton disabled={!nicknameAvailable || submitting} onClick={handleSubmit}>
+          <NextButton disabled={submitting} onClick={handleSubmit}>
             {submitting ? '가입 중...' : '제출'}
           </NextButton>
           <UndoButton />


### PR DESCRIPTION
### 작업 내용

## 닉네임 회원가입 섹션 
`nickname-section.tsx`
- 제출 버튼 항상 활성화 상태로 변경
- 중복검사 없이 제출 시 "닉네임 중복 검사를 진행해 주세요" 에러 메시지 표시
- alert() 제거하고 인라인 에러 메시지(빨간색 + 느낌표 아이콘)로 변경


### 연관 이슈
#116 

