### PR TITLE
feat: (탐색) 브리더 목록 페이지네이션 및 더보기 버튼 추가

### DIFF
--- a/src/app/(main)/explore/_hooks/use-breeders.ts
+++ b/src/app/(main)/explore/_hooks/use-breeders.ts
@@ -1,15 +1,19 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
 import { exploreBreeders, getPopularBreeders, type Breeder, type SearchBreederParams } from '@/lib/breeder';
 
+const PAGE_SIZE = 10;
+
 /**
- * 브리더 목록 검색/필터링 hook
+ * 브리더 목록 검색/필터링 hook (무한스크롤/페이지네이션)
  */
-export function useBreeders(params: SearchBreederParams = {}) {
-  return useQuery({
+export function useBreeders(params: Omit<SearchBreederParams, 'page' | 'take'> = {}) {
+  return useInfiniteQuery({
     queryKey: ['breeders', params],
-    queryFn: () => exploreBreeders(params),
+    queryFn: ({ pageParam = 1 }) => exploreBreeders({ ...params, page: pageParam, take: PAGE_SIZE }),
+    getNextPageParam: (lastPage) => (lastPage.pagination.hasNextPage ? lastPage.pagination.currentPage + 1 : undefined),
+    initialPageParam: 1,
     staleTime: 1000 * 60 * 5, // 5분
   });
 }

--- a/src/components/breeder-list/breeder-list.tsx
+++ b/src/components/breeder-list/breeder-list.tsx
@@ -1,15 +1,3 @@
-import { Fragment } from 'react';
-import { Separator } from '../ui/separator';
-
-export default function BreederList({ children }: { children: React.ReactNode[] }) {
-  return (
-    <div className="flex flex-col space-y-6">
-      {children.map((child, index) => (
-        <Fragment key={index}>
-          {child}
-          {index !== children.length - 1 && <Separator />}
-        </Fragment>
-      ))}
-    </div>
-  );
+export default function BreederList({ children }: { children: React.ReactNode }) {
+  return <div className="flex flex-col">{children}</div>;
 }


### PR DESCRIPTION
### 작업 내용
##  브리더 목록 페이지네이션 및 더보기 버튼 추가
- useBreeders 훅을 useQuery → useInfiniteQuery로 변경하여 페이지네이션 지원
- 페이지당 10개씩 로드, 다음 페이지가 있을 때 더보기 버튼 표시
- 브리더 카드 사이에 Separator 추가 (더보기 버튼 바로 위 요소에는 제외)


### 연관 이슈
#116 
