### PR TITLE
feat: (브리더 프로필) 후기 전체보기 페이지 추가 및 페이지네이션 수정

### DIFF
--- a/src/app/(main)/explore/breeder/[id]/_components/review.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/review.tsx
@@ -20,7 +20,7 @@ export default function Review({ data }: { data: { id: string; nickname: string;
           </div>
           <Button
             variant="ghost"
-            className="p-0 gap-1 text-grayscale-gray5 text-body-xs"
+            className="gap-1 text-grayscale-gray5 text-body-xs px-0 has-[>svg]:px-0"
             onClick={() => setIsReportDialogOpen(true)}
           >
             <SirenMuted className="size-5" />

--- a/src/app/(main)/explore/breeder/[id]/_components/reviews.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/reviews.tsx
@@ -1,18 +1,30 @@
+import Link from 'next/link';
 import BreederProfileSection from '@/components/breeder-profile/breeder-profile-section';
 import BreederProfileSectionHeader from '@/components/breeder-profile/breeder-profile-section-header';
 import BreederProfileSectionMore from '@/components/breeder-profile/breeder-profile-section-more';
 import BreederProfileSectionTitle from '@/components/breeder-profile/breeder-profile-section-title';
 import Review from './review';
 
-export default function Reviews({ data }: { data: { id: string; nickname: string; date: string; content: string }[] }) {
+interface ReviewsProps {
+  data: { id: string; nickname: string; date: string; content: string }[];
+  breederId: string;
+}
+
+export default function Reviews({ data, breederId }: ReviewsProps) {
+  const displayedReviews = data.slice(0, 5);
+
   return (
     <BreederProfileSection>
       <BreederProfileSectionHeader>
         <BreederProfileSectionTitle>후기</BreederProfileSectionTitle>
-        {data.length > 5 && <BreederProfileSectionMore />}
+        {data.length > 5 && (
+          <Link href={`/explore/breeder/${breederId}/reviews`}>
+            <BreederProfileSectionMore />
+          </Link>
+        )}
       </BreederProfileSectionHeader>
       <div className="flex flex-col gap-8">
-        {data.map((e: { id: string; nickname: string; date: string; content: string }) => (
+        {displayedReviews.map((e: { id: string; nickname: string; date: string; content: string }) => (
           <Review key={e.id} data={e} />
         ))}
       </div>

--- a/src/app/(main)/explore/breeder/[id]/_hooks/use-breeder-detail.ts
+++ b/src/app/(main)/explore/breeder/[id]/_hooks/use-breeder-detail.ts
@@ -83,3 +83,19 @@ export function useBreederReviews(breederId: string, page: number = 1, limit: nu
     staleTime: 1000 * 60 * 5,
   });
 }
+
+/**
+ * 브리더 후기 목록 조회 훅 (무한 스크롤)
+ */
+export function useBreederReviewsInfinite(breederId: string, limit: number = 5) {
+  return useInfiniteQuery({
+    queryKey: ['breeder-reviews-infinite', breederId, limit],
+    queryFn: ({ pageParam = 1 }) => getBreederReviews(breederId, pageParam, limit),
+    getNextPageParam: (lastPage) => {
+      return lastPage.pagination?.hasNextPage ? lastPage.pagination.currentPage + 1 : undefined;
+    },
+    initialPageParam: 1,
+    enabled: !!breederId,
+    staleTime: 1000 * 60 * 5,
+  });
+}

--- a/src/app/(main)/explore/breeder/[id]/page.tsx
+++ b/src/app/(main)/explore/breeder/[id]/page.tsx
@@ -280,7 +280,7 @@ export default function Page({ params }: PageProps) {
             </>
           )}
 
-          {!isReviewsLoading && reviews.length > 0 && <Reviews data={reviews} />}
+          {!isReviewsLoading && reviews.length > 0 && <Reviews data={reviews} breederId={breederId} />}
         </div>
       </div>
       {!isLg && (

--- a/src/app/(main)/explore/breeder/[id]/parents/page.tsx
+++ b/src/app/(main)/explore/breeder/[id]/parents/page.tsx
@@ -22,7 +22,7 @@ export default function ParentsPage({ params }: PageProps) {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useParentPetsInfinite(breederId, 10);
+  } = useParentPetsInfinite(breederId, 8);
 
   // 날짜 포맷팅 함수 (브리더 상세 페이지와 동일)
   const formatBirthDate = (dateString: string | Date | undefined) => {
@@ -102,8 +102,8 @@ export default function ParentsPage({ params }: PageProps) {
                   <AnimalProfile key={parent.id} data={parent} />
                 ))}
               </div>
-              {/* 더보기 버튼 - 첫 페이지가 10개 이상이고 다음 페이지가 있을 때만 표시 */}
-              {firstPageCount >= 10 && hasNextPage && (
+              {/* 더보기 버튼 - 첫 페이지가 8개 이상이고 다음 페이지가 있을 때만 표시 */}
+              {firstPageCount >= 8 && hasNextPage && (
                 <div className="flex justify-center">
                   <Button
                     variant="ghost"

--- a/src/app/(main)/explore/breeder/[id]/pets/page.tsx
+++ b/src/app/(main)/explore/breeder/[id]/pets/page.tsx
@@ -24,7 +24,7 @@ export default function PetsPage({ params }: PageProps) {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useBreederPetsInfinite(breederId, 10);
+  } = useBreederPetsInfinite(breederId, 8);
 
   // 날짜 포맷팅 함수 (브리더 상세 페이지와 동일)
   const formatBirthDate = (dateString: string | Date | undefined) => {
@@ -105,8 +105,8 @@ export default function PetsPage({ params }: PageProps) {
                   <AnimalProfile key={pet.id} data={pet} />
                 ))}
               </div>
-              {/* 더보기 버튼 - 첫 페이지가 10개 이상이고 다음 페이지가 있을 때만 표시 */}
-              {firstPageCount >= 10 && hasNextPage && (
+              {/* 더보기 버튼 - 첫 페이지가 8개 이상이고 다음 페이지가 있을 때만 표시 */}
+              {firstPageCount >= 8 && hasNextPage && (
                 <div className="flex justify-center">
                   <Button
                     variant="ghost"

--- a/src/app/(main)/explore/breeder/[id]/reviews/page.tsx
+++ b/src/app/(main)/explore/breeder/[id]/reviews/page.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { use } from 'react';
+import Header from '../../_components/header';
+import Review from '../_components/review';
+import { useBreederProfile, useBreederReviewsInfinite } from '../_hooks/use-breeder-detail';
+import { Button } from '@/components/ui/button';
+import DownArrow from '@/assets/icons/long-down-arrow.svg';
+
+interface PageProps {
+  params: Promise<{
+    id: string;
+  }>;
+}
+
+export default function ReviewsPage({ params }: PageProps) {
+  const { id: breederId } = use(params);
+  const { data: profileData } = useBreederProfile(breederId);
+  const {
+    data: reviewsData,
+    isLoading: isReviewsLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useBreederReviewsInfinite(breederId, 10);
+
+  // 모든 페이지의 데이터를 합쳐서 매핑
+  const allReviews =
+    reviewsData?.pages
+      .flatMap((page) => page.items || [])
+      .map((review: { reviewId: string; adopterNickname: string; createdAt: string; content: string }) => ({
+        id: review.reviewId,
+        nickname: review.adopterNickname,
+        date: new Date(review.createdAt).toLocaleDateString('ko-KR'),
+        content: review.content,
+      })) || [];
+
+  // 첫 페이지의 총 개수 확인 (더보기 버튼 표시 여부 결정용)
+  const firstPageCount = reviewsData?.pages[0]?.items?.length || 0;
+
+  return (
+    <>
+      <Header breederNickname={profileData?.breederName || ''} breederId={breederId} hideActions />
+      <div className="pt-4 pb-20">
+        <div className="flex flex-col items-center gap-10">
+          {/* 헤더 */}
+          <div className="w-full flex">
+            <h1 className="text-heading-3 font-semibold text-primary text-center">후기</h1>
+          </div>
+
+          {/* 콘텐츠 */}
+          {isReviewsLoading ? (
+            <div className="flex items-center justify-center py-20">
+              <p className="text-body-s text-grayscale-gray5">로딩 중...</p>
+            </div>
+          ) : allReviews.length === 0 ? (
+            <div className="flex items-center justify-center py-20">
+              <p className="text-body-s text-grayscale-gray5">등록된 후기가 없습니다.</p>
+            </div>
+          ) : (
+            <div className="w-full flex flex-col items-center gap-10 md:gap-[60px] lg:gap-20">
+              <div className="w-full flex flex-col gap-8">
+                {allReviews.map((review) => (
+                  <Review key={review.id} data={review} />
+                ))}
+              </div>
+              {/* 더보기 버튼 - 첫 페이지가 5개 이상이고 다음 페이지가 있을 때만 표시 */}
+              {firstPageCount >= 10 && hasNextPage && (
+                <div className="flex justify-center">
+                  <Button
+                    variant="ghost"
+                    onClick={() => fetchNextPage()}
+                    disabled={isFetchingNextPage}
+                    className="bg-[var(--color-grayscale-gray1)] hover:bg-[var(--color-grayscale-gray2)] h-12 py-2.5 gap-1 rounded-full has-[>svg]:px-0 has-[>svg]:pl-5 has-[>svg]:pr-3 disabled:opacity-50"
+                  >
+                    <span className="text-body-s font-medium text-grayscale-gray6">
+                      {isFetchingNextPage ? '로딩 중...' : '더보기'}
+                    </span>
+                    <DownArrow />
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/breeder-profile/breeder-profile-section-more.tsx
+++ b/src/components/breeder-profile/breeder-profile-section-more.tsx
@@ -3,7 +3,7 @@ import { Button } from '../ui/button';
 
 export default function BreederProfileSectionMore() {
   return (
-    <Button type="button" variant="ghost" className="gap-1 p-0 text-grayscale-gray5 text-body-xs">
+    <Button type="button" variant="ghost" className="gap-1 has-[>svg]:px-0 text-grayscale-gray5 text-body-xs">
       <div>더보기</div>
       <ChevronRight className="size-3.5" />
     </Button>


### PR DESCRIPTION
### 작업 내용

## 후기 전체보기 페이지 추가
- 브리더 프로필 후기 섹션에서 5개 초과 시 더보기 버튼 → 후기 전체보기 페이지로 이동
- 후기 전체보기 페이지: 10개씩 로드, 10개 초과 시 더보기 버튼
- useBreederReviewsInfinite 훅 추가 (무한 스크롤 지원)
## 페이지네이션 수정
- 분양 중인 아이들/엄마 아빠 전체보기 페이지: 10개 → 8개씩 로드로 변경
## 신고하기 버튼 UI 수정
- 패딩 제거 (has-[>svg]:px-0)

### 연관 이슈
#155 
