### PR TITLE
feat: (브리더 프로필) 분양 중인 아이/엄마아빠 상세 정보 다이얼로그 추가

### DIFF
--- a/src/app/(main)/explore/breeder/[id]/_components/animal-profile.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/animal-profile.tsx
@@ -12,6 +12,7 @@ const sexInfo = {
 
 export default function AnimalProfile({
   data: { avatarUrl, name, sex, birth, price, breed, status },
+  onClick,
 }: {
   data: {
     avatarUrl: string;
@@ -22,6 +23,7 @@ export default function AnimalProfile({
     breed: string;
     status?: 'available' | 'reserved' | 'completed';
   };
+  onClick?: () => void;
 }) {
   const Icon = sexInfo[sex].icon;
 
@@ -37,7 +39,7 @@ export default function AnimalProfile({
   };
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 cursor-pointer" onClick={onClick}>
       <div className="relative aspect-square overflow-hidden rounded-lg">
         <Image
           src={getValidImageUrl(avatarUrl)}

--- a/src/app/(main)/explore/breeder/[id]/_components/breeding-animals.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/breeding-animals.tsx
@@ -1,15 +1,19 @@
 'use client';
 
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import BreederProfileSection from '@/components/breeder-profile/breeder-profile-section';
 import BreederProfileSectionHeader from '@/components/breeder-profile/breeder-profile-section-header';
 import BreederProfileSectionMore from '@/components/breeder-profile/breeder-profile-section-more';
 import BreederProfileSectionTitle from '@/components/breeder-profile/breeder-profile-section-title';
 import AnimalProfile from './animal-profile';
+import PetDetailDialog, { type PetDetailData } from './pet-detail-dialog';
+import { useParentPets } from '../_hooks/use-breeder-detail';
 
 export default function BreedingAnimals({
   data,
   breederId,
+  breederDescription,
 }: {
   data: {
     id: string;
@@ -19,13 +23,72 @@ export default function BreedingAnimals({
     birth: string;
     price: string | null;
     breed: string;
+    status?: 'available' | 'reserved' | 'completed';
+    description?: string;
   }[];
   breederId: string;
+  breederDescription?: string;
 }) {
   const router = useRouter();
+  const [selectedPet, setSelectedPet] = useState<PetDetailData | null>(null);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const { data: parentPetsData } = useParentPets(breederId, 1, 100);
 
   const handleMoreClick = () => {
     router.push(`/explore/breeder/${breederId}/pets`);
+  };
+
+  const handlePetClick = (pet: (typeof data)[0]) => {
+    // 부모 정보 찾기 (pet.id와 매칭되는 부모 찾기)
+    // 실제로는 API에서 pet의 parentInfo를 가져와야 하지만, 여기서는 간단히 처리
+    const parents =
+      parentPetsData?.items?.map(
+        (parent: {
+          petId: string;
+          photoUrl?: string;
+          name: string;
+          gender: 'male' | 'female';
+          birthDate?: string;
+          breed: string;
+        }) => ({
+          id: parent.petId,
+          avatarUrl: parent.photoUrl || '/animal-sample.png',
+          name: parent.name,
+          sex: parent.gender,
+          birth: formatBirthDate(parent.birthDate),
+          breed: parent.breed,
+        }),
+      ) || [];
+
+    const petDetail: PetDetailData = {
+      id: pet.id,
+      avatarUrl: pet.avatarUrl,
+      name: pet.name,
+      sex: pet.sex,
+      birth: pet.birth,
+      price: pet.price,
+      breed: pet.breed,
+      status: pet.status || 'available',
+      description: pet.description,
+      parents: parents,
+    };
+
+    setSelectedPet(petDetail);
+    setIsDialogOpen(true);
+  };
+
+  const formatBirthDate = (dateString: string | Date | undefined) => {
+    if (!dateString) return '';
+    try {
+      const date = new Date(dateString);
+      if (isNaN(date.getTime())) return '';
+      const year = date.getFullYear();
+      const month = date.getMonth() + 1;
+      const day = date.getDate();
+      return `${year}년 ${month}월 ${day}일 생`;
+    } catch {
+      return '';
+    }
   };
 
   return (
@@ -50,11 +113,21 @@ export default function BreedingAnimals({
               birth: string;
               price: string | null;
               breed: string;
+              status?: 'available' | 'reserved' | 'completed';
+              description?: string;
             }) => (
-              <AnimalProfile key={e.id} data={e} />
+              <AnimalProfile key={e.id} data={e} onClick={() => handlePetClick(e)} />
             ),
           )}
       </div>
+      <PetDetailDialog
+        open={isDialogOpen}
+        onOpenChange={setIsDialogOpen}
+        pet={selectedPet}
+        type="pet"
+        breederId={breederId}
+        breederDescription={breederDescription}
+      />
     </BreederProfileSection>
   );
 }

--- a/src/app/(main)/explore/breeder/[id]/_components/parents.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/parents.tsx
@@ -1,15 +1,18 @@
 'use client';
 
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import BreederProfileSection from '@/components/breeder-profile/breeder-profile-section';
 import BreederProfileSectionHeader from '@/components/breeder-profile/breeder-profile-section-header';
 import BreederProfileSectionMore from '@/components/breeder-profile/breeder-profile-section-more';
 import BreederProfileSectionTitle from '@/components/breeder-profile/breeder-profile-section-title';
 import AnimalProfile from './animal-profile';
+import PetDetailDialog, { type PetDetailData } from './pet-detail-dialog';
 
 export default function Parents({
   data,
   breederId,
+  breederDescription,
 }: {
   data: {
     id: string;
@@ -19,13 +22,32 @@ export default function Parents({
     birth: string;
     price: string;
     breed: string;
+    description?: string;
   }[];
   breederId: string;
+  breederDescription?: string;
 }) {
   const router = useRouter();
+  const [selectedPet, setSelectedPet] = useState<PetDetailData | null>(null);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const handleMoreClick = () => {
     router.push(`/explore/breeder/${breederId}/parents`);
+  };
+
+  const handlePetClick = (pet: (typeof data)[0]) => {
+    const petDetail: PetDetailData = {
+      id: pet.id,
+      avatarUrl: pet.avatarUrl,
+      name: pet.name,
+      sex: pet.sex,
+      birth: pet.birth,
+      breed: pet.breed,
+      description: pet.description,
+    };
+
+    setSelectedPet(petDetail);
+    setIsDialogOpen(true);
   };
 
   return (
@@ -50,11 +72,20 @@ export default function Parents({
               birth: string;
               price: string;
               breed: string;
+              description?: string;
             }) => (
-              <AnimalProfile key={e.id} data={e} />
+              <AnimalProfile key={e.id} data={e} onClick={() => handlePetClick(e)} />
             ),
           )}
       </div>
+      <PetDetailDialog
+        open={isDialogOpen}
+        onOpenChange={setIsDialogOpen}
+        pet={selectedPet}
+        type="parent"
+        breederId={breederId}
+        breederDescription={breederDescription}
+      />
     </BreederProfileSection>
   );
 }

--- a/src/app/(main)/explore/breeder/[id]/_components/pet-detail-dialog.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/pet-detail-dialog.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogClose } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import Female from '@/assets/icons/female';
+import Male from '@/assets/icons/male';
+import AdoptionStatusBadge from '@/components/adoption-status-badge';
+import Image from 'next/image';
+import { Separator } from '@/components/ui/separator';
+import { useRouter } from 'next/navigation';
+import { useCounselFormStore } from '@/stores/counsel-form-store';
+import { useAuthStore } from '@/stores/auth-store';
+import { cn } from '@/lib/utils';
+
+import RightArrow from '@/assets/icons/right-arrow.svg';
+import Close from '@/assets/icons/close';
+
+const sexInfo = {
+  male: { icon: Male, className: 'text-gender-male-500' },
+  female: { icon: Female, className: 'text-gender-female-500' },
+};
+
+export interface PetDetailData {
+  id: string;
+  avatarUrl: string;
+  name: string;
+  sex: 'male' | 'female';
+  birth: string;
+  price?: string | null;
+  breed: string;
+  status?: 'available' | 'reserved' | 'completed';
+  description?: string;
+  parents?: {
+    id: string;
+    avatarUrl: string;
+    name: string;
+    sex: 'male' | 'female';
+    birth: string;
+    breed: string;
+  }[];
+}
+
+interface PetDetailDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  pet: PetDetailData | null;
+  type: 'pet' | 'parent';
+  breederId: string;
+  breederDescription?: string;
+}
+
+export default function PetDetailDialog({
+  open,
+  onOpenChange,
+  pet,
+  type,
+  breederId,
+  breederDescription,
+}: PetDetailDialogProps) {
+  const router = useRouter();
+  const { clearCounselFormData } = useCounselFormStore();
+  const { isAuthenticated } = useAuthStore();
+  const [selectedParent, setSelectedParent] = useState<PetDetailData | null>(null);
+  const [isParentDialogOpen, setIsParentDialogOpen] = useState(false);
+
+  if (!pet) return null;
+
+  const Icon = sexInfo[pet.sex].icon;
+
+  const getValidImageUrl = (url: string) => {
+    if (!url) return '/animal-sample.png';
+    if (url.startsWith('http://') || url.startsWith('https://')) return url;
+    return '/animal-sample.png';
+  };
+
+  const handleCounselClick = () => {
+    if (!isAuthenticated) {
+      router.push('/login');
+      return;
+    }
+    clearCounselFormData();
+    router.push(`/counselform?breederId=${breederId}`);
+    onOpenChange(false);
+  };
+
+  const handleParentClick = (parent: {
+    id: string;
+    avatarUrl: string;
+    name: string;
+    sex: 'male' | 'female';
+    birth: string;
+    breed: string;
+  }) => {
+    // 현재 다이얼로그 닫기
+    onOpenChange(false);
+
+    // 부모 정보를 PetDetailData로 변환
+    const parentDetail: PetDetailData = {
+      id: parent.id,
+      avatarUrl: parent.avatarUrl,
+      name: parent.name,
+      sex: parent.sex,
+      birth: parent.birth,
+      breed: parent.breed,
+    };
+
+    setSelectedParent(parentDetail);
+    setIsParentDialogOpen(true);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-w-[37.5rem] w-full max-h-[37.5rem] overflow-hidden flex flex-col p-0 gap-0 rounded-2xl"
+        showCloseButton={false}
+      >
+        {/* 헤더 */}
+        <div className="flex flex-col gap-[10px] items-start pt-6 px-6 pb-[10px]">
+          <div className="flex gap-1 items-center justify-end w-full">
+            <DialogClose asChild>
+              <Button variant="secondary" size="icon">
+                <Close className="size-7" />
+                <span className="sr-only">닫기</span>
+              </Button>
+            </DialogClose>
+          </div>
+        </div>
+
+        {/* 구분선 */}
+        <Separator />
+
+        {/* 스크롤 가능한 콘텐츠 영역 */}
+        <div className="bg-white flex flex-col gap-7 min-h-0 overflow-y-auto px-6 pt-5 pb-10">
+          {/* 프로필 이미지 */}
+          <div className="flex justify-center">
+            <div className="relative w-[17.5rem] h-[17.5rem] rounded-2xl overflow-hidden">
+              <Image
+                src={getValidImageUrl(pet.avatarUrl)}
+                alt={`${pet.name}의 사진`}
+                fill
+                className="object-cover"
+                unoptimized={getValidImageUrl(pet.avatarUrl).startsWith('http')}
+              />
+            </div>
+          </div>
+
+          {/* 기본 정보 */}
+          <div className="flex flex-col gap-5">
+            <div className="flex flex-col gap-3">
+              {/* 이름, 성별, 생년월일, 입양 금액대 */}
+              <div className="flex flex-col gap-1.5">
+                <div className="flex items-center gap-0.5">
+                  <h3 className="text-heading-3 font-semibold text-primary-500">{pet.name}</h3>
+                  <Icon className={cn('w-5 h-5', sexInfo[pet.sex].className)} />
+                </div>
+                <div className="text-body-s text-grayscale-gray5">{pet.birth}</div>
+                {type === 'pet' && pet.price !== null && (
+                  <div className="text-body-s text-grayscale-gray5">{pet.price}</div>
+                )}
+              </div>
+
+              {/* 입양 가능 배지 + 품종 */}
+              <div className="flex items-center gap-2 flex-wrap">
+                {type === 'pet' && pet.status && <AdoptionStatusBadge status={pet.status} />}
+                <div className="rounded bg-tertiary-500 py-1.5 px-2.5 text-body-xs font-medium text-primary-500">
+                  {pet.breed}
+                </div>
+              </div>
+            </div>
+
+            {/* 소개 내용 - 브리더 소개글 */}
+            {breederDescription && (
+              <div className="text-body-s text-grayscale-gray6 whitespace-pre-wrap">{breederDescription}</div>
+            )}
+          </div>
+
+          {/* 엄마아빠 섹션 (분양 중인 아이만) */}
+          {type === 'pet' && pet.parents && pet.parents.length > 0 && (
+            <>
+              <Separator />
+              <div className="flex flex-col gap-3.5">
+                <h4 className="text-body-m font-semibold text-grayscale-gray6">엄마 · 아빠</h4>
+                <div className="flex flex-col gap-3.5">
+                  {pet.parents.map((parent) => (
+                    <div key={parent.id} className="flex items-center gap-6">
+                      <div className="relative w-[6.25rem] h-[6.25rem] rounded-lg overflow-hidden flex-shrink-0">
+                        <Image
+                          src={getValidImageUrl(parent.avatarUrl)}
+                          alt={`${parent.name}의 사진`}
+                          fill
+                          className="object-cover"
+                          unoptimized={getValidImageUrl(parent.avatarUrl).startsWith('http')}
+                        />
+                      </div>
+                      <div className="flex-1 flex flex-col gap-1.5">
+                        <div className="flex items-center gap-0.5">
+                          <span className="text-body-m font-semibold text-primary-500">{parent.name}</span>
+                          {(() => {
+                            const ParentIcon = sexInfo[parent.sex].icon;
+                            return <ParentIcon className={cn('w-5 h-5', sexInfo[parent.sex].className)} />;
+                          })()}
+                        </div>
+                        <div className="text-body-s text-grayscale-gray5">{parent.birth}</div>
+                      </div>
+                      <Button
+                        variant="ghost"
+                        className="text-body-xs text-grayscale-gray5 gap-1 h-auto p-0"
+                        onClick={() => handleParentClick(parent)}
+                      >
+                        보기
+                        <RightArrow className="size-5" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* 구분선 */}
+        <Separator />
+
+        {/* 하단 버튼 */}
+        <div className="flex justify-end gap-2.5 px-6 py-4">
+          {type === 'pet' ? (
+            <Button
+              variant="tertiary"
+              className="h-9 px-4 text-body-medium text-primary-500 rounded-sm"
+              onClick={handleCounselClick}
+            >
+              상담 신청하기
+            </Button>
+          ) : (
+            <Button
+              variant="tertiary"
+              className="h-9 px-4 text-body-medium text-primary-500 rounded-sm min-w-[4.5rem]"
+              onClick={() => onOpenChange(false)}
+            >
+              닫기
+            </Button>
+          )}
+        </div>
+      </DialogContent>
+
+      {/* 부모 다이얼로그 */}
+      {selectedParent && (
+        <PetDetailDialog
+          open={isParentDialogOpen}
+          onOpenChange={setIsParentDialogOpen}
+          pet={selectedParent}
+          type="parent"
+          breederId={breederId}
+          breederDescription={breederDescription}
+        />
+      )}
+    </Dialog>
+  );
+}

--- a/src/app/(main)/explore/breeder/[id]/page.tsx
+++ b/src/app/(main)/explore/breeder/[id]/page.tsx
@@ -204,6 +204,8 @@ export default function Page({ params }: PageProps) {
     birth: formatBirthDate(pet.birthDate),
     price: user ? `${pet.price?.toLocaleString() || 0}원` : null,
     breed: pet.breed,
+    status:
+      pet.status === 'adopted' ? 'completed' : ((pet.status || 'available') as 'available' | 'reserved' | 'completed'),
   }));
 
   // 부모견/부모묘 매핑 - 페이지네이션 응답 형태 처리
@@ -268,14 +270,14 @@ export default function Page({ params }: PageProps) {
 
           {!isPetsLoading && breedingAnimals.length > 0 && (
             <>
-              <BreedingAnimals data={breedingAnimals} breederId={breederId} />
+              <BreedingAnimals data={breedingAnimals} breederId={breederId} breederDescription={breederDescription} />
               <Separator className="my-12" />
             </>
           )}
 
           {!isParentPetsLoading && parentPets.length > 0 && (
             <>
-              <Parents data={parentPets} breederId={breederId} />
+              <Parents data={parentPets} breederId={breederId} breederDescription={breederDescription} />
               <Separator className="my-12" />
             </>
           )}

--- a/src/app/(main)/explore/breeder/[id]/parents/page.tsx
+++ b/src/app/(main)/explore/breeder/[id]/parents/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { use } from 'react';
+import { use, useState } from 'react';
 import Header from '../../_components/header';
 import AnimalProfile from '../_components/animal-profile';
 import { useBreederProfile, useParentPetsInfinite } from '../_hooks/use-breeder-detail';
 import { Button } from '@/components/ui/button';
 import DownArrow from '@/assets/icons/long-down-arrow.svg';
+import PetDetailDialog, { type PetDetailData } from '../_components/pet-detail-dialog';
 
 interface PageProps {
   params: Promise<{
@@ -23,6 +24,8 @@ export default function ParentsPage({ params }: PageProps) {
     hasNextPage,
     isFetchingNextPage,
   } = useParentPetsInfinite(breederId, 8);
+  const [selectedPet, setSelectedPet] = useState<PetDetailData | null>(null);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   // 날짜 포맷팅 함수 (브리더 상세 페이지와 동일)
   const formatBirthDate = (dateString: string | Date | undefined) => {
@@ -76,6 +79,24 @@ export default function ParentsPage({ params }: PageProps) {
   // 첫 페이지의 총 개수 확인 (더보기 버튼 표시 여부 결정용)
   const firstPageCount = parentPetsData?.pages[0]?.items?.length || 0;
 
+  // 브리더 소개글 가져오기
+  const breederDescription =
+    (profileData as any)?.description || (profileData as any)?.profileInfo?.profileDescription || '';
+
+  const handlePetClick = (pet: MappedParentPet) => {
+    const petDetail: PetDetailData = {
+      id: pet.id,
+      avatarUrl: pet.avatarUrl,
+      name: pet.name,
+      sex: pet.sex,
+      birth: pet.birth,
+      breed: pet.breed,
+    };
+
+    setSelectedPet(petDetail);
+    setIsDialogOpen(true);
+  };
+
   return (
     <>
       <Header breederNickname={profileData?.breederName || ''} breederId={breederId} hideActions />
@@ -99,9 +120,17 @@ export default function ParentsPage({ params }: PageProps) {
             <div className="w-full flex flex-col items-center gap-10 md:gap-[60px] lg:gap-20">
               <div className="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
                 {allParentPets.map((parent) => (
-                  <AnimalProfile key={parent.id} data={parent} />
+                  <AnimalProfile key={parent.id} data={parent} onClick={() => handlePetClick(parent)} />
                 ))}
               </div>
+              <PetDetailDialog
+                open={isDialogOpen}
+                onOpenChange={setIsDialogOpen}
+                pet={selectedPet}
+                type="parent"
+                breederId={breederId}
+                breederDescription={breederDescription}
+              />
               {/* 더보기 버튼 - 첫 페이지가 8개 이상이고 다음 페이지가 있을 때만 표시 */}
               {firstPageCount >= 8 && hasNextPage && (
                 <div className="flex justify-center">


### PR DESCRIPTION
### 작업 내용


## 공통 다이얼로그 컴포넌트 생성
`pet-detail-dialog.tsx`
- 분양 중인 아이와 엄마아빠 정보를 표시하는 재사용 가능한 다이얼로그 컴포넌트
- 분양 중인 아이와 엄마아빠 타입에 따라 다른 UI 표시
- 브리더 소개글 표시 기능 포함

## 브리더 프로필 페이지 다이얼로그 연동
- `breeding-animals.tsx`: 분양 중인 아이들 카드 클릭 시 다이얼로그 표시
- `parents.tsx`: 엄마아빠 카드 클릭 시 다이얼로그 표시
- `animal-profile.tsx`: 클릭 핸들러 추가 및 상태 배지 표시

## 상세 페이지 다이얼로그 연동
- `/pets` 페이지: 분양 중인 아이들 목록에서 카드 클릭 시 다이얼로그 표시
- `/parents` 페이지: 엄마아빠 목록에서 카드 클릭 시 다이얼로그 표시

## 다이얼로그 내 네비게이션
- 분양 중인 아이 다이얼로그에서 엄마아빠 "보기" 버튼 클릭 시 해당 엄마아빠 다이얼로그로 전환

## 상태 배지 표시
- 브리더 프로필 페이지의 분양 중인 아이들 카드에 입양 가능/예약중/입양 완료 상태 배지 표시




### 연관 이슈
#155 
