### PR TITLE
feat : 토스트 메세지 위치 시스템 구현 및 페이지별 위치 설정

### DIFF
--- a/src/app/(main)/application/_components/application-detail-modal.tsx
+++ b/src/app/(main)/application/_components/application-detail-modal.tsx
@@ -32,6 +32,7 @@ const ApplicationDetailModal = ({ open, onOpenChange, applicationId }: Applicati
       toast({
         title: '상담 완료',
         description: '상담이 완료되었습니다. 입양자에게 알림이 전송되었습니다.',
+        position: 'default',
       });
       queryClient.invalidateQueries({ queryKey: ['application', applicationId] });
       queryClient.invalidateQueries({ queryKey: ['applications'] });
@@ -41,6 +42,7 @@ const ApplicationDetailModal = ({ open, onOpenChange, applicationId }: Applicati
       toast({
         title: '오류',
         description: error.message || '상담 완료 처리 중 오류가 발생했습니다.',
+        position: 'default',
       });
     },
   });
@@ -55,6 +57,7 @@ const ApplicationDetailModal = ({ open, onOpenChange, applicationId }: Applicati
       toast({
         title: '완료 취소',
         description: '상담 완료가 취소되었습니다.',
+        position: 'default',
       });
       queryClient.invalidateQueries({ queryKey: ['application', applicationId] });
       queryClient.invalidateQueries({ queryKey: ['applications'] });
@@ -63,6 +66,7 @@ const ApplicationDetailModal = ({ open, onOpenChange, applicationId }: Applicati
       toast({
         title: '오류',
         description: error.message || '완료 취소 처리 중 오류가 발생했습니다.',
+        position: 'default',
       });
     },
   });

--- a/src/app/(main)/application/_components/review-write-dialog.tsx
+++ b/src/app/(main)/application/_components/review-write-dialog.tsx
@@ -72,6 +72,7 @@ export default function ReviewWriteDialog({
       queryClient.invalidateQueries({ queryKey: ['review-by-application', applicationId] });
       toast({
         title: '후기가 작성되었습니다.',
+        position: 'default',
       });
       onOpenChange(false);
       router.push('/myapplication');
@@ -80,6 +81,7 @@ export default function ReviewWriteDialog({
       toast({
         title: '후기 작성에 실패했습니다.',
         description: error instanceof Error ? error.message : '다시 시도해주세요.',
+        position: 'default',
       });
     },
   });
@@ -88,6 +90,7 @@ export default function ReviewWriteDialog({
     if (!reviewText.trim()) {
       toast({
         title: '후기 내용을 입력해주세요.',
+        position: 'default',
       });
       return;
     }
@@ -205,9 +208,7 @@ export default function ReviewWriteDialog({
               <div className="box-border flex flex-col gap-[var(--space-16)] items-start overflow-clip pb-0 pt-[var(--space-12)] px-[var(--space-16)] relative shrink-0 w-full">
                 {existingReview ? (
                   // 기존 후기 표시 (읽기 전용)
-                  <div className="min-h-[140px] text-body-s text-grayscale-gray6 whitespace-pre-wrap">
-                    {reviewText}
-                  </div>
+                  <div className="min-h-[140px] text-body-s text-grayscale-gray6 whitespace-pre-wrap">{reviewText}</div>
                 ) : (
                   // 후기 작성 (편집 가능)
                   <Textarea

--- a/src/app/(main)/counselform/page.tsx
+++ b/src/app/(main)/counselform/page.tsx
@@ -118,6 +118,7 @@ function CounselFormContent() {
     if (!isValid) {
       toast({
         title: '입력 정보를 확인해주세요.',
+        position: 'split',
       });
       return;
     }
@@ -126,6 +127,7 @@ function CounselFormContent() {
       toast({
         title: '브리더 정보가 없습니다.',
         description: '브리더 페이지에서 다시 시도해주세요.',
+        position: 'split',
       });
       return;
     }
@@ -161,6 +163,7 @@ function CounselFormContent() {
       toast({
         title: '상담 신청이 완료되었습니다.',
         description: result.message,
+        position: 'split',
       });
 
       // 신청 목록 페이지로 이동
@@ -170,6 +173,7 @@ function CounselFormContent() {
       toast({
         title: '상담 신청에 실패했습니다.',
         description: error instanceof Error ? error.message : '다시 시도해주세요.',
+        position: 'split',
       });
     }
   };

--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -312,11 +312,13 @@ export default function ProfilePage() {
         setProfileData(formData);
         toast({
           title: '프로필이 수정되었습니다.',
+          position: 'split',
         });
       } catch (error) {
         toast({
           title: '프로필 수정에 실패했습니다.',
           description: error instanceof Error ? error.message : '다시 시도해주세요.',
+          position: 'split',
         });
       }
     }

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -60,6 +60,7 @@ export default function SettingsPage() {
         toast({
           title: '프로필 로드 실패',
           description: '프로필 정보를 불러올 수 없습니다.',
+          position: 'default',
         });
       } finally {
         setIsLoading(false);
@@ -78,6 +79,7 @@ export default function SettingsPage() {
         toast({
           title: '브리더 이름 변경',
           description: '브리더 이름은 관리자에게 문의해주세요.',
+          position: 'default',
         });
         return;
       } else {
@@ -87,12 +89,14 @@ export default function SettingsPage() {
         toast({
           title: '닉네임 변경 완료',
           description: '닉네임이 성공적으로 변경되었습니다.',
+          position: 'default',
         });
       }
     } catch (error) {
       toast({
         title: '닉네임 변경 실패',
         description: error instanceof Error ? error.message : '다시 시도해주세요.',
+        position: 'default',
       });
     }
   };
@@ -113,11 +117,13 @@ export default function SettingsPage() {
       toast({
         title: checked ? '마케팅 수신 동의' : '마케팅 수신 거부',
         description: checked ? '광고성 정보 수신에 동의하셨습니다.' : '광고성 정보 수신을 거부하셨습니다.',
+        position: 'default',
       });
     } catch (error) {
       toast({
         title: '설정 변경 실패',
         description: error instanceof Error ? error.message : '다시 시도해주세요.',
+        position: 'default',
       });
     }
   };
@@ -140,6 +146,7 @@ export default function SettingsPage() {
         toast({
           title: '브리더 계정 탈퇴 완료',
           description: '그동안 이용해 주셔서 감사합니다.',
+          position: 'default',
         });
       } else {
         // 입양자 회원 탈퇴 API 호출 (탈퇴 사유 포함)
@@ -151,6 +158,7 @@ export default function SettingsPage() {
         toast({
           title: '회원 탈퇴 완료',
           description: '그동안 이용해 주셔서 감사합니다.',
+          position: 'default',
         });
       }
 
@@ -167,6 +175,7 @@ export default function SettingsPage() {
       toast({
         title: '탈퇴 처리 실패',
         description: error instanceof Error ? error.message : '다시 시도해주세요.',
+        position: 'default',
       });
     }
   };
@@ -194,11 +203,7 @@ export default function SettingsPage() {
           <Separator className="bg-grayscale-gray2" />
 
           {/* 닉네임 */}
-          <NicknameSection
-            nickname={nickname}
-            onEdit={handleNicknameEdit}
-            editable={user?.role !== 'breeder'}
-          />
+          <NicknameSection nickname={nickname} onEdit={handleNicknameEdit} editable={user?.role !== 'breeder'} />
           <Separator className="bg-grayscale-gray2" />
 
           {/* 이메일 수신 설정 */}

--- a/src/app/signup/_components/sections/document-section.tsx
+++ b/src/app/signup/_components/sections/document-section.tsx
@@ -110,6 +110,7 @@ export default function DocumentSection() {
       toast({
         title: '로그인 정보 없음',
         description: '소셜 로그인 정보가 없습니다. 다시 로그인해주세요.',
+        position: 'split',
       });
       router.push('/login');
       return;
@@ -171,11 +172,13 @@ export default function DocumentSection() {
         toast({
           title: '회원가입 실패',
           description: error.message,
+          position: 'split',
         });
       } else {
         toast({
           title: '회원가입 실패',
           description: '회원가입에 실패했습니다.',
+          position: 'split',
         });
       }
     } finally {
@@ -199,6 +202,7 @@ export default function DocumentSection() {
       toast({
         title: '로그인 정보 없음',
         description: '소셜 로그인 정보가 없습니다. 다시 로그인해주세요.',
+        position: 'split',
       });
       router.push('/login');
       return;
@@ -276,11 +280,13 @@ export default function DocumentSection() {
         toast({
           title: '회원가입 실패',
           description: error.message,
+          position: 'split',
         });
       } else {
         toast({
           title: '회원가입 실패',
           description: '회원가입에 실패했습니다.',
+          position: 'split',
         });
       }
     } finally {

--- a/src/app/signup/_components/sections/user-info-section.tsx
+++ b/src/app/signup/_components/sections/user-info-section.tsx
@@ -99,6 +99,7 @@ export default function UserInfoSection() {
       toast({
         title: '올바른 휴대폰 번호를 입력해주세요',
         description: '휴대폰 번호 형식을 확인해주세요.',
+        position: 'split',
       });
       return;
     }
@@ -113,6 +114,7 @@ export default function UserInfoSection() {
       toast({
         title: '인증번호 발송 완료',
         description: '휴대폰으로 인증번호를 발송했습니다.',
+        position: 'split',
       });
     } catch (error) {
       // API 에러 메시지 파싱
@@ -169,6 +171,7 @@ export default function UserInfoSection() {
             toast({
               title: '이미 가입된 이메일입니다',
               description: '로그인 페이지로 이동합니다.',
+              position: 'split',
             });
             setTimeout(() => {
               router.push('/login');

--- a/src/components/gnb/mobile-nav-item.tsx
+++ b/src/components/gnb/mobile-nav-item.tsx
@@ -141,6 +141,7 @@ function CollapsibleNavSection({ item, isLast }: { item: NavItem; isLast: boolea
       toast({
         title: '로그아웃 실패',
         description: error instanceof Error ? error.message : '다시 시도해주세요.',
+        position: 'default',
       });
     }
   };

--- a/src/components/gnb/nav-bar.tsx
+++ b/src/components/gnb/nav-bar.tsx
@@ -170,6 +170,7 @@ export default function NavBar({ navVariant = 'default' }: NavBarProps) {
       toast({
         title: '로그아웃 완료',
         description: '성공적으로 로그아웃되었습니다.',
+        position: 'default',
       });
       // 하드 리다이렉트로 모든 상태 초기화
       window.location.href = '/';
@@ -177,6 +178,7 @@ export default function NavBar({ navVariant = 'default' }: NavBarProps) {
       toast({
         title: '로그아웃 실패',
         description: error instanceof Error ? error.message : '다시 시도해주세요.',
+        position: 'default',
       });
     }
   };

--- a/src/components/report-dialog/report-dialog.tsx
+++ b/src/components/report-dialog/report-dialog.tsx
@@ -88,6 +88,7 @@ export default function ReportDialog({
       toast({
         title: '신고 실패',
         description: error instanceof Error ? error.message : '신고 처리 중 오류가 발생했습니다.',
+        position: 'default',
       });
     } finally {
       setIsSubmitting(false);

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -4,22 +4,31 @@ import * as React from 'react';
 import * as ToastPrimitives from '@radix-ui/react-toast';
 import { cn } from '@/lib/utils';
 import Close from '@/assets/icons/close.svg';
+import type { ToastPosition } from '@/hooks/use-toast';
 
 const ToastProvider = ToastPrimitives.Provider;
 
 const ToastViewport = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Viewport>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Viewport
-    ref={ref}
-    className={cn(
-      'fixed z-[100] flex max-h-screen flex-col-reverse p-0 bottom-[calc(1.5rem+3rem+0.75rem)] left-1/2 -translate-x-1/2  md:bottom-[calc(2.5rem+3rem+0.75rem)] md:left-[calc(50%+20%)] md:-translate-x-1/2',
-      className,
-    )}
-    {...props}
-  />
-));
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport> & {
+    position?: ToastPosition;
+  }
+>(({ className, position = 'default', ...props }, ref) => {
+  const positionClasses = {
+    default:
+      'bottom-[calc(1.5rem+3rem+0.75rem)] left-1/2 -translate-x-1/2 md:bottom-[calc(2.5rem+3rem+0.75rem)] md:left-1/2 md:-translate-x-1/2',
+    split:
+      'bottom-[calc(1.5rem+3rem+0.75rem)] left-1/2 -translate-x-1/2 md:bottom-[calc(2.5rem+3rem+0.75rem)] md:left-[75%] md:-translate-x-1/2',
+  };
+
+  return (
+    <ToastPrimitives.Viewport
+      ref={ref}
+      className={cn('fixed z-[100] flex max-h-screen flex-col-reverse p-0', positionClasses[position], className)}
+      {...props}
+    />
+  );
+});
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
 
 const Toast = React.forwardRef<

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -3,26 +3,46 @@
 import { Toast, ToastClose, ToastDescription, ToastProvider, ToastTitle, ToastViewport } from '@/components/ui/toast';
 import { useToast } from '@/hooks/use-toast';
 import Check from '@/assets/icons/check';
+import type { ToastPosition } from '@/hooks/use-toast';
 
 export function Toaster() {
   const { toasts } = useToast();
 
+  // position별로 토스트 그룹화
+  const toastsByPosition = toasts.reduce((acc, toast) => {
+    const position = (toast.position || 'default') as ToastPosition;
+    if (!acc[position]) {
+      acc[position] = [];
+    }
+    acc[position].push(toast);
+    return acc;
+  }, {} as Record<ToastPosition, typeof toasts>);
+
+  const positions: ToastPosition[] = ['default', 'split'];
+
   return (
-    <ToastProvider>
-      {toasts.map(function ({ id, title, description, action, ...props }) {
+    <>
+      {positions.map((position) => {
+        const positionToasts = toastsByPosition[position] || [];
         return (
-          <Toast key={id} {...props}>
-            <div className="flex items-center gap-1 grow box-shadow: 0 0 13px 0 rgba(12, 17, 29, 0.08)">
-              <Check className="size-5 text-[#f6f6ea] shrink-0" />
-              {title && <ToastTitle>{title}</ToastTitle>}
-              {description && <ToastDescription>{description}</ToastDescription>}
-            </div>
-            {action}
-            <ToastClose />
-          </Toast>
+          <ToastProvider key={position}>
+            {positionToasts.map(function ({ id, title, description, action, ...props }) {
+              return (
+                <Toast key={id} {...props}>
+                  <div className="flex items-center gap-1 grow box-shadow: 0 0 13px 0 rgba(12, 17, 29, 0.08)">
+                    <Check className="size-5 text-[#f6f6ea] shrink-0" />
+                    {title && <ToastTitle>{title}</ToastTitle>}
+                    {description && <ToastDescription>{description}</ToastDescription>}
+                  </div>
+                  {action}
+                  <ToastClose />
+                </Toast>
+              );
+            })}
+            <ToastViewport position={position} />
+          </ToastProvider>
         );
       })}
-      <ToastViewport />
-    </ToastProvider>
+    </>
   );
 }

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -4,11 +4,14 @@ import type { ToastActionElement, ToastProps } from '@/components/ui/toast';
 const TOAST_LIMIT = 1;
 const TOAST_REMOVE_DELAY = 1000; // Toast가 사라지기까지의 지연 시간 (1초)
 
+export type ToastPosition = 'default' | 'split';
+
 type ToasterToast = ToastProps & {
   id: string;
   title?: React.ReactNode;
   description?: React.ReactNode;
   action?: ToastActionElement;
+  position?: ToastPosition;
 };
 
 let count = 0;
@@ -129,7 +132,7 @@ function dispatch(action: Action) {
 
 type Toast = Omit<ToasterToast, 'id'>;
 
-function toast({ ...props }: Toast) {
+function toast({ position = 'default', ...props }: Toast) {
   const id = genId();
 
   const update = (props: ToasterToast) =>
@@ -144,6 +147,7 @@ function toast({ ...props }: Toast) {
     toast: {
       ...props,
       id,
+      position,
       open: true,
       duration: props.duration ?? 2000, // 기본 2초 후 자동으로 사라짐
       onOpenChange: (open) => {


### PR DESCRIPTION
### 작업 내용


## 토스트 위치 시스템 구현
- `ToastPosition` 타입 추가: `'default' | 'split' 
- 각 위치별 스타일 정의:
  - **default**: 화면 중앙 정렬 (기본)
  - **split**: 오른쪽 영역 내부 중앙 정렬 (회원가입, 상담 신청, 프로필 페이지용)


## 토스트 컴포넌트 개선
- `ToastViewport`에 position prop 추가
- `Toaster` 컴포넌트에서 position별로 별도의 Provider 생성
- 각 position에 맞는 Viewport 렌더링



### 연관 이슈
#116 
