### PR TITLE
Feat/#116

### DIFF
--- a/src/constants/document.ts
+++ b/src/constants/document.ts
@@ -1,7 +1,7 @@
 // 서류 미제출 경고 메시지
 export const DOCUMENT_ERROR_MESSAGES = {
   BREEDER_CERT: '해당되는 서류를 하나 골라 첨부해 주세요',
-  REQUIRED_DOCUMENTS: '필수 서류를 제출해주세요',
+  REQUIRED_DOCUMENTS: '필수 서류를 첨부해 주세요',
   FILE_SIZE_LIMIT: '파일은 최대 10MB까지 업로드할 수 있어요',
 } as const;
 


### PR DESCRIPTION
### 작업 내용

##  필수 서류 검증 로직 개선
- 브리더 인증 서류(강아지/고양이)는 필수 검증에서 제외
- 엘리트 레벨: 신분증 사본, 동물생산업 등록증, 표준 입양계약서 샘플 (3개 필수)
- 뉴 레벨: 신분증 사본, 동물생산업 등록증 (2개 필수)

## 필수 서류 미제출 시 에러 표시 추가
- 각 필수 서류 항목에 에러 아이콘(느낌표) 및 "필수 서류를 첨부해 주세요" 메시지 표시
- 신분증 사본, 동물생산업 등록증, 표준 입양계약서 샘플(엘리트만) 각각에 에러 표시

##  입점 서약서 체크 검증 추가
- 입점 서약서를 체크하지 않은 상태로 제출 시 에러 표시
- 에러 아이콘과 "입점 서약서에 동의해 주세요" 메시지 표시

## 엘리트/뉴 서약서 체크 상태 분리
- 엘리트와 뉴 레벨의 입점 서약서 체크 상태를 별개로 관리
- 레벨 변경 시 서약서 체크 상태가 독립적으로 유지되도록 개선

## 에러 메시지 텍스트 수정
- "필수 서류를 제출해주세요" → "필수 서류를 첨부해 주세요"로 변경


### 연관 이슈
#116 
