### PR TITLE
feat : 베이직 레벨 브리더의 엄마/아빠 개체 정보 추가 제한

### DIFF
--- a/src/app/(main)/profile/_components/parents-info.tsx
+++ b/src/app/(main)/profile/_components/parents-info.tsx
@@ -22,7 +22,13 @@ import type { ProfileFormData } from '@/stores/profile-store';
 import ErrorMessage from '@/components/error-message';
 import { BREEDER_PROFILE_ERROR } from '@/constants/errors/breeder-profile-error';
 
-export default function ParentsInfo({ form }: { form: ReturnType<typeof useFormContext<ProfileFormData>> }) {
+export default function ParentsInfo({
+  form,
+  maxParents,
+}: {
+  form: ReturnType<typeof useFormContext<ProfileFormData>>;
+  maxParents?: number;
+}) {
   const { control, watch, formState, getValues, setValue } = form;
   const { errors } = formState;
   const selectedBreeds = watch('breeds');
@@ -46,7 +52,7 @@ export default function ParentsInfo({ form }: { form: ReturnType<typeof useFormC
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const MAX_PARENTS = 100; // 충분히 큰 값으로 설정하여 제한 없음
+  const MAX_PARENTS = maxParents ?? 100;
 
   const addParent = () => {
     if (fields.length >= MAX_PARENTS) return;

--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -354,7 +354,7 @@ export default function ProfilePage() {
               onProfileImageChange={handleProfileImageChange}
             />
             {/* 엄마 아빠 정보 */}
-            <ParentsInfo form={form} />
+            <ParentsInfo form={form} maxParents={apiProfileData?.verificationInfo?.level === 'new' ? 4 : undefined} />
             {/* 분양 중인 아이 */}
             <BreedingAnimals form={form} />
             {/* 탈퇴하기 링크 */}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -5,10 +5,7 @@ export default function NotFound() {
     <div className="flex flex-col items-center justify-center min-h-screen px-4">
       <h1 className="text-4xl font-bold text-primary mb-4">404</h1>
       <p className="text-body-m text-grayscale-gray5 mb-6">페이지를 찾을 수 없습니다</p>
-      <Link
-        href="/"
-        className="px-6 py-3 bg-primary text-white rounded-lg hover:opacity-90 transition-opacity"
-      >
+      <Link href="/" className="px-6 py-3 bg-primary text-white rounded-lg hover:opacity-90 transition-opacity">
         홈으로 돌아가기
       </Link>
     </div>


### PR DESCRIPTION
### 작업 내용



## 베이직 레벨 브리더의 엄마/아빠 개체 정보 추가 제한
- 베이직(new) 레벨 브리더는 엄마/아빠 동물 개체 정보를 최대 4마리까지 추가 가능하도록 제한
- 엘리트 레벨 브리더는 기존과 동일하게 무제한 추가 가능




### 연관 이슈
#116
