### PR TITLE
fix : 베이직 레벨 브리더의 엄마/아빠 개체 정보 추가 제한 오류 수정

### DIFF
--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -354,7 +354,14 @@ export default function ProfilePage() {
               onProfileImageChange={handleProfileImageChange}
             />
             {/* 엄마 아빠 정보 */}
-            <ParentsInfo form={form} maxParents={apiProfileData?.verificationInfo?.level === 'new' ? 4 : undefined} />
+            <ParentsInfo
+              form={form}
+              maxParents={
+                apiProfileData?.verificationInfo?.level !== 'elite' && (apiProfileData as any)?.breederLevel !== 'elite'
+                  ? 4
+                  : undefined
+              }
+            />
             {/* 분양 중인 아이 */}
             <BreedingAnimals form={form} />
             {/* 탈퇴하기 링크 */}


### PR DESCRIPTION
### 작업 내용

## 베이직 레벨 브리더의 엄마/아빠 개체 정보 추가 제한 오류 수정
- 엘리트 레벨 아닐 경우로 수정
### 연관 이슈
#116 