### PR TITLE
fix : 베이직 레벨 -> 베이직 플랜 브리더의 엄마/아빠 개체 정보 제한으로 변경

### DIFF
--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -354,14 +354,7 @@ export default function ProfilePage() {
               onProfileImageChange={handleProfileImageChange}
             />
             {/* 엄마 아빠 정보 */}
-            <ParentsInfo
-              form={form}
-              maxParents={
-                apiProfileData?.verificationInfo?.level !== 'elite' && (apiProfileData as any)?.breederLevel !== 'elite'
-                  ? 4
-                  : undefined
-              }
-            />
+            <ParentsInfo form={form} maxParents={apiProfileData?.verificationInfo?.plan === 'basic' ? 4 : undefined} />
             {/* 분양 중인 아이 */}
             <BreedingAnimals form={form} />
             {/* 탈퇴하기 링크 */}


### PR DESCRIPTION
### 작업 내용

## 베이직 레벨 -> 베이직 플랜 브리더의 엄마/아빠 개체 정보 제한으로 변경
- 베이직 레벨 -> 베이직 플랜 
### 연관 이슈
#116 
