### PR TITLE
fix: 브리더 프로필 수정 페이지 입양 비용 범위 UX 개선 및 고양이 브리더 품종 다이얼로그 수정

### DIFF
--- a/src/app/(main)/profile/_components/parents-info.tsx
+++ b/src/app/(main)/profile/_components/parents-info.tsx
@@ -10,7 +10,7 @@ import Plus from '@/assets/icons/plus.svg';
 import Female from '@/assets/icons/female.svg';
 import PictureRemove from '@/assets/icons/picture-delete.svg';
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { cn } from '@/lib/utils';
 import {
   DropdownMenu,
@@ -323,7 +323,7 @@ export default function ParentsInfo({
                       {...field}
                       placeholder="소개"
                       maxLength={1500}
-                      showLength={field.value && field.value.length > 0}
+                      showLength={(field.value?.length ?? 0) > 0}
                       currentLength={field.value?.length || 0}
                     />
                   )}

--- a/src/app/(main)/profile/_components/profile-basic-info.tsx
+++ b/src/app/(main)/profile/_components/profile-basic-info.tsx
@@ -33,7 +33,7 @@ export default function ProfileBasicInfo({
   animal = 'dog',
 }: ProfileBasicInfoProps) {
   const [isDescriptionFocused, setIsDescriptionFocused] = useState(false);
-  const { control, watch, setValue, formState, trigger } = form;
+  const { control, watch, setValue, clearErrors, formState, trigger } = form;
   const { errors } = formState;
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -261,15 +261,21 @@ export default function ProfileBasicInfo({
               )}
             />
             <button
+              type="button"
               onClick={() => {
-                if (!isCounselMode) {
-                  // 상담 후 공개 모드로 전환 시 값 초기화
-                  setValue('minPrice', '', { shouldValidate: true });
-                  setValue('maxPrice', '', { shouldValidate: true });
+                const nextIsCounselMode = !isCounselMode;
+
+                // 분양중인 아이들 섹션과 동일하게:
+                // - 토글만으로도 "수정하기" 버튼이 활성화되도록 shouldDirty
+                // - 토글 순간 즉시 에러가 뜨지 않도록 shouldValidate는 끔
+                setValue('isCounselMode', nextIsCounselMode, { shouldDirty: true, shouldValidate: false });
+
+                if (nextIsCounselMode) {
+                  // 상담 후 공개 모드로 전환 시 값 초기화 + 기존 에러 제거
+                  setValue('minPrice', '', { shouldDirty: true, shouldValidate: false });
+                  setValue('maxPrice', '', { shouldDirty: true, shouldValidate: false });
+                  clearErrors(['minPrice', 'maxPrice']);
                 }
-                setValue('isCounselMode', !isCounselMode, {
-                  shouldValidate: true,
-                });
               }}
               className="button-after-counsel shrink-0 whitespace-nowrap"
             >

--- a/src/app/(main)/profile/profile-schema.ts
+++ b/src/app/(main)/profile/profile-schema.ts
@@ -26,7 +26,7 @@ const birthDateSchema = z
   );
 
 const locationSchema = z
-  .string({ required_error: BREEDER_PROFILE_ERROR.LOCATION_REQUIRED })
+  .string()
   .min(1, BREEDER_PROFILE_ERROR.LOCATION_REQUIRED)
   .refine((val) => val.trim() !== '', {
     message: BREEDER_PROFILE_ERROR.LOCATION_REQUIRED,

--- a/src/app/signup/_components/client-page.tsx
+++ b/src/app/signup/_components/client-page.tsx
@@ -12,6 +12,7 @@ import UserInfoSection from './sections/user-info-section';
 import UserTypeSection from './sections/user-type-section';
 const flowInfo: Record<UserType, React.ComponentType[]> = {
   guest: [UserTypeSection, UserInfoSection, NicknameSection, SignupComplete],
+  adopter: [UserTypeSection, UserInfoSection, NicknameSection, SignupComplete],
   breeder: [
     UserTypeSection,
     AnimalSection,

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useLayoutEffect } from 'react';
 import { useAuthStore } from '@/stores/auth-store';
+import type { VerificationStatus } from '@/stores/auth-store';
 import { getAdopterProfile } from '@/lib/adopter';
 import { getMyBreederProfile } from '@/lib/breeder';
 import { getUserRoleFromCookie } from '@/lib/cookie-utils';
@@ -46,10 +47,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
         if (cookieRole === 'breeder') {
           const profile = await getMyBreederProfile();
-          const verificationStatus =
-            (profile.verificationInfo as any)?.status ||
-            profile.verificationInfo?.verificationStatus ||
-            'pending';
+          const rawStatus = profile.verificationInfo?.status;
+          // auth-store는 reviewing 상태를 따로 관리하지 않아 pending으로 매핑
+          const verificationStatus: VerificationStatus =
+            rawStatus === 'approved' || rawStatus === 'rejected' ? rawStatus : 'pending';
           setUser({
             userId: profile.breederId,
             email: profile.breederEmail,


### PR DESCRIPTION
### 작업 내용



## 브리더 프로필 수정 페이지 - 입양 비용 범위 UX 개선
-  입양 비용 범위 초기값(0-0)을 placeholder(회색)로 표시하도록 수정
-  "상담 후 공개" 버튼 클릭 시 즉시 에러 메시지가 표시되지 않도록 수정
-  "상담 후 공개" 버튼 클릭 시 "수정하기" 버튼이 활성화되도록 수정 

## 고양이 브리더 품종 다이얼로그 수정
-  고양이 브리더의 경우 품종 다이얼로그가 고양이 품종으로 열리도록 수정




