### PR TITLE
design : 상담 폼 페이지 UI 개선

### DIFF
--- a/src/app/(main)/counselform/page.tsx
+++ b/src/app/(main)/counselform/page.tsx
@@ -198,7 +198,7 @@ function CounselFormContent() {
     <FormProvider {...form}>
       <div className="sticky top-0 z-10 w-full py-6 bg-tertiary-500-basic">
         <ExitConfirmDialog hasData={hasFormData}>
-          <button className="bg-primary-500-basic size-9 flex gap-2.5 items-center justify-center rounded-lg hover:bg-tertiary-600">
+          <button className="bg-white size-9 flex gap-2.5 items-center justify-center rounded-lg hover:bg-tertiary-600">
             <LeftArrow />
           </button>
         </ExitConfirmDialog>
@@ -206,8 +206,8 @@ function CounselFormContent() {
       <div className="min-h-screen flex w-full flex-col md:flex-row">
         {/* 왼쪽 배너 영역: md 이상에서만 표시 */}
         {isMdUp && (
-          <div className="md:w-1/2 md:p-8 bg-tertiary-500">
-            <div className="md:h-[calc(100vh-4rem)]">
+          <div className="md:w-[648px] md:pr-8 bg-tertiary-500">
+            <div className="md:h-[744px]">
               <CounselBannerCarousel />
             </div>
           </div>
@@ -607,7 +607,7 @@ function CounselFormContent() {
             <Button
               variant={undefined}
               disabled={isDisabled}
-              className="button-edit-default text-primary-500 hover:bg-secondary-600 flex h-12 items-center justify-center min-w-20 px-4 py-3 rounded-lg w-full md:w-[424px] disabled:opacity-50 disabled:cursor-not-allowed"
+              className="button-edit-default text-primary-500 hover:bg-secondary-600 flex h-12 items-center justify-center min-w-20 px-4 py-3 rounded-lg w-full md:w-[424px] disabled:cursor-not-allowed disabled:text-grayscale-gray4"
               onClick={handleSubmit}
             >
               {createApplicationMutation.isPending ? '제출 중...' : '상담 신청하기'}

--- a/src/components/counsel-banner/counsel-banner-carousel.tsx
+++ b/src/components/counsel-banner/counsel-banner-carousel.tsx
@@ -79,7 +79,7 @@ export default function CounselBannerCarousel() {
     <div className="relative w-full h-full group">
       {/* Banner Image */}
       <div
-        className={`w-full h-full overflow-hidden rounded-lg ${currentBanner.linkUrl ? 'cursor-pointer' : ''}`}
+        className={`w-full h-full overflow-hidden rounded-[20px] ${currentBanner.linkUrl ? 'cursor-pointer' : ''}`}
         onClick={() => currentBanner.linkUrl && handleBannerClick(currentBanner)}
       >
         <img


### PR DESCRIPTION
### 작업 내용


## 배너 영역 크기 조정
   - 왼쪽 배너 영역 너비: `md:w-1/2` → `md:w-[648px]`
   - 왼쪽 배너 영역 높이: `md:h-[calc(100vh-4rem)]` → `md:h-[744px]`


## 배너 이미지 border-radius 적용
   - `rounded-lg` → `rounded-[20px]`
## 상담 신청하기 버튼 스타일 개선
 - 비활성화 시 투명도 삭제,  폰트 색 수정
