### PR TITLE
fix : (브리더 프로필 수정하기) 수정하기 안되던 오류 수정

### DIFF
--- a/src/app/(main)/explore/breeder/[id]/_components/reviews.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/reviews.tsx
@@ -23,7 +23,7 @@ export default function Reviews({ data, breederId }: ReviewsProps) {
           </Link>
         )}
       </BreederProfileSectionHeader>
-      <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-8 ">
         {displayedReviews.map((e: { id: string; nickname: string; date: string; content: string }) => (
           <Review key={e.id} data={e} />
         ))}

--- a/src/app/(main)/explore/breeder/[id]/page.tsx
+++ b/src/app/(main)/explore/breeder/[id]/page.tsx
@@ -350,6 +350,15 @@ export default function Page({ params }: PageProps) {
     };
   });
 
+  // 목 데이터 추가 (테스트용)
+  const mockReview = {
+    id: 'mock-review-1',
+    nickname: '김입양',
+    date: '2024-12-20',
+    content: '입양후기테스트입양후기테스트',
+  };
+  const reviewsWithMock = [...reviews, mockReview];
+
   return (
     <>
       <Header breederNickname={profileData.breederName} breederId={breederId} />
@@ -357,7 +366,7 @@ export default function Page({ params }: PageProps) {
         <div>
           <BreederProfile data={breederProfileData} breederId={breederId} isOwnProfile={isOwnProfile} />
         </div>
-        <div className="space-y-12 mt-10 md:mt-0">
+        <div className="space-y-12 w-full mt-10 md:mt-0">
           {envPhotos.length > 0 && (
             <>
               <EnvPhotos photos={envPhotos} />
@@ -386,7 +395,7 @@ export default function Page({ params }: PageProps) {
             </>
           )}
 
-          {!isReviewsLoading && reviews.length > 0 && <Reviews data={reviews} breederId={breederId} />}
+          {!isReviewsLoading && reviewsWithMock.length > 0 && <Reviews data={reviewsWithMock} breederId={breederId} />}
         </div>
       </div>
       {!isLg && (

--- a/src/app/(main)/profile/_components/profile-basic-info.tsx
+++ b/src/app/(main)/profile/_components/profile-basic-info.tsx
@@ -225,27 +225,19 @@ export default function ProfileBasicInfo({
               name="minPrice"
               control={control}
               render={({ field }) => {
-                const maxPriceValue = watch('maxPrice') || '';
+                // 분양중인 아이들 섹션과 동일한 로직
+                const displayValue = isCounselMode ? '' : formatPrice(field.value || '');
                 return (
                   <PriceInput
                     placeholder={isCounselMode ? '상담 후 공개' : '0'}
                     className="grow"
                     inputMode="numeric"
                     disabled={isCounselMode}
-                    value={isCounselMode ? '' : formatPrice(field.value || '')}
+                    value={displayValue}
                     onChange={(e) => {
                       const digits = normalizeNumber(e.target.value);
-                      const minNum = digits ? Number(digits) : 0;
-                      const maxNum = maxPriceValue ? Number(maxPriceValue) : 0;
-
-                      // 최소 금액이 최대 금액보다 크면 자동 swap
-                      if (digits && maxPriceValue && minNum > maxNum) {
-                        setValue('minPrice', maxPriceValue, { shouldDirty: true, shouldValidate: false });
-                        setValue('maxPrice', digits, { shouldDirty: true, shouldValidate: false });
-                        clearErrors(['minPrice', 'maxPrice']);
-                      } else {
-                        field.onChange(digits);
-                      }
+                      // 자동 swap 제거 - 입력한 값 그대로 저장
+                      field.onChange(digits);
                     }}
                     onBlur={field.onBlur}
                   />
@@ -259,27 +251,19 @@ export default function ProfileBasicInfo({
               name="maxPrice"
               control={control}
               render={({ field }) => {
-                const minPriceValue = watch('minPrice') || '';
+                // 분양중인 아이들 섹션과 동일한 로직
+                const displayValue = isCounselMode ? '' : formatPrice(field.value || '');
                 return (
                   <PriceInput
                     placeholder={isCounselMode ? '상담 후 공개' : '0'}
                     className="grow"
                     inputMode="numeric"
                     disabled={isCounselMode}
-                    value={isCounselMode ? '' : formatPrice(field.value || '')}
+                    value={displayValue}
                     onChange={(e) => {
                       const digits = normalizeNumber(e.target.value);
-                      const minNum = minPriceValue ? Number(minPriceValue) : 0;
-                      const maxNum = digits ? Number(digits) : 0;
-
-                      // 최대 금액이 최소 금액보다 작으면 자동 swap
-                      if (digits && minPriceValue && maxNum < minNum) {
-                        setValue('minPrice', digits, { shouldDirty: true, shouldValidate: false });
-                        setValue('maxPrice', minPriceValue, { shouldDirty: true, shouldValidate: false });
-                        clearErrors(['minPrice', 'maxPrice']);
-                      } else {
-                        field.onChange(digits);
-                      }
+                      // 자동 swap 제거 - 입력한 값 그대로 저장
+                      field.onChange(digits);
                     }}
                     onBlur={field.onBlur}
                   />
@@ -297,7 +281,7 @@ export default function ProfileBasicInfo({
                 setValue('isCounselMode', nextIsCounselMode, { shouldDirty: true, shouldValidate: false });
 
                 if (nextIsCounselMode) {
-                  // 상담 후 공개 모드로 전환 시 값 초기화 + 기존 에러 제거
+                  // 상담 후 공개 모드로 전환 시 빈 문자열로 설정 (placeholder "상담 후 공개" 표시) + 기존 에러 제거
                   setValue('minPrice', '', { shouldDirty: true, shouldValidate: false });
                   setValue('maxPrice', '', { shouldDirty: true, shouldValidate: false });
                   clearErrors(['minPrice', 'maxPrice']);

--- a/src/utils/profile-validation.ts
+++ b/src/utils/profile-validation.ts
@@ -97,7 +97,7 @@ export function isFormEmpty(data: ProfileFormData): boolean {
 /**
  * 부모 항목이 비어있는지 확인 (id 제외)
  */
-function isParentEmpty(parent: ProfileFormData['parents'][number]): boolean {
+export function isParentEmpty(parent: ProfileFormData['parents'][number]): boolean {
   return (
     (!parent.name || parent.name.trim() === '') &&
     (!parent.breed || parent.breed.length === 0) &&
@@ -145,7 +145,7 @@ export function validateParents(parents: ProfileFormData['parents']): Array<Pare
 /**
  * 분양 개체 항목이 비어있는지 확인 (id 제외)
  */
-function isAnimalEmpty(animal: ProfileFormData['animals'][number]): boolean {
+export function isAnimalEmpty(animal: ProfileFormData['animals'][number]): boolean {
   return (
     (!animal.name || animal.name.trim() === '') &&
     (!animal.breed || animal.breed.length === 0) &&


### PR DESCRIPTION
### 작업 내용



### 문제 상황
- 브리더 수정하기 페이지에서 변경사항이 있을 때 수정하기 버튼이 활성화되지만 API 호출이 발생하지 않는 문제
- 빈 부모/아이 항목이 zod 스키마 검증에서 필수로 요구되어 검증 실패로 인해 API 호출이 차단됨

## Zod 스키마 조건부 검증 적용
   - 비어있는 부모/아이 항목은 검증을 스킵하도록 `superRefine`으로 조건부 검증 구현
   - 각 필드에 기본값(default) 설정하여 빈 값도 파싱 통과하도록 수정


