### PR TITLE
feat: 브라우저 네비게이션 가드 공통 훅 적용

### DIFF
--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -27,6 +27,7 @@ import { uploadSingleFile, uploadRepresentativePhotos } from '@/lib/upload';
 import ProfileBannerCarousel from '@/components/profile-banner/profile-banner-carousel';
 import useFormGuard from '@/hooks/use-form-guard';
 import ExitConfirmDialog from '@/components/exit-confirmation-dialog';
+import useBrowserNavigationGuard from '@/hooks/use-browser-navigation-guard';
 
 type BreederProfileApi = {
   breederName?: string;
@@ -302,6 +303,11 @@ export default function ProfilePage() {
     hasChanges,
   });
 
+  // 브라우저 이전/다음/새로고침 가드 훅
+  const { showBrowserGuard, handleBrowserConfirm, handleBrowserCancel } = useBrowserNavigationGuard({
+    hasChanges,
+  });
+
   // 프로필 이미지 변경 핸들러
   const handleProfileImageChange = (file: File, preview: string) => {
     setProfileImageFile(file);
@@ -555,6 +561,20 @@ export default function ProfilePage() {
           onOpenChange={(open) => {
             if (!open) {
               handleNavigationCancel();
+            }
+          }}
+        />
+      )}
+
+      {showBrowserGuard && (
+        <ExitConfirmDialog
+          hasData={hasChanges}
+          onConfirm={handleBrowserConfirm}
+          onCancel={handleBrowserCancel}
+          open={showBrowserGuard}
+          onOpenChange={(open) => {
+            if (!open) {
+              handleBrowserCancel();
             }
           }}
         />

--- a/src/hooks/use-browser-navigation-guard.ts
+++ b/src/hooks/use-browser-navigation-guard.ts
@@ -1,0 +1,69 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseBrowserNavigationGuardOptions {
+  hasChanges: boolean | (() => boolean);
+  enabled?: boolean;
+}
+
+/**
+ * 브라우저 뒤로가기/앞으로가기/새로고침 시 작성 중단 확인 모달을 띄우기 위한 가드 훅
+ * - 커스텀 모달은 popstate에서만 가능
+ * - 새로고침/탭 닫기는 브라우저 기본 confirm만 가능 (beforeunload)
+ */
+export default function useBrowserNavigationGuard({ hasChanges, enabled = true }: UseBrowserNavigationGuardOptions) {
+  const [showBrowserGuard, setShowBrowserGuard] = useState(false);
+  const allowNavigationRef = useRef(false);
+
+  const checkHasChanges = useCallback(
+    () => (typeof hasChanges === 'function' ? hasChanges() : hasChanges),
+    [hasChanges],
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    // 현재 위치를 히스토리에 추가해 popstate에서 동일 위치로 복구
+    window.history.pushState(null, '', window.location.href);
+
+    const handlePopState = (event: PopStateEvent) => {
+      if (!checkHasChanges() || allowNavigationRef.current) return;
+      event.preventDefault();
+      // 이동 취소 후 모달 표시
+      window.history.pushState(null, '', window.location.href);
+      setShowBrowserGuard(true);
+    };
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!checkHasChanges()) return;
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [checkHasChanges, enabled]);
+
+  const handleBrowserConfirm = () => {
+    allowNavigationRef.current = true;
+    setShowBrowserGuard(false);
+    window.history.back();
+  };
+
+  const handleBrowserCancel = () => {
+    allowNavigationRef.current = false;
+    setShowBrowserGuard(false);
+  };
+
+  return {
+    showBrowserGuard,
+    handleBrowserConfirm,
+    handleBrowserCancel,
+  };
+}


### PR DESCRIPTION
### 작업 내용


## 브라우저 이전/다음/새로고침 가드 공통 훅 분리
- `use-browser-navigation-guard` 훅 추가
## 브리더 프로필 수정, 상담 신청 폼에 적용

- 프로필 수정/상담 폼에서 훅 사용하여 모달 표시
- 새로고침/탭 닫기 시 기본 확인창 유지



