### PR TITLE
fix: 브리더 프로필 후기 타입 라벨 오류 수정

### DIFF
--- a/src/app/(main)/explore/breeder/[id]/_components/review.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/review.tsx
@@ -6,9 +6,14 @@ import { Button } from '@/components/ui/button';
 import { useBreakpoint } from '@/hooks/use-breakpoint';
 import ReportDialog from '@/components/report-dialog/report-dialog';
 
-export default function Review({ data }: { data: { id: string; nickname: string; date: string; content: string } }) {
+export default function Review({
+  data,
+}: {
+  data: { id: string; nickname: string; date: string; content: string; reviewType?: string };
+}) {
   const isMobile = !useBreakpoint('md');
   const [isReportDialogOpen, setIsReportDialogOpen] = useState(false);
+  const typeLabel = data.reviewType || '후기';
 
   return (
     <>
@@ -16,7 +21,11 @@ export default function Review({ data }: { data: { id: string; nickname: string;
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <div className="text-body-s font-semibold text-grayscale-gray5">{data.nickname}</div>
-            {!isMobile && <div className="text-body-s text-grayscale-gray5">입양 후기・{data.date}</div>}
+            {!isMobile && (
+              <div className="text-body-s text-grayscale-gray5">
+                {typeLabel}・{data.date}
+              </div>
+            )}
           </div>
           <Button
             variant="ghost"
@@ -27,7 +36,11 @@ export default function Review({ data }: { data: { id: string; nickname: string;
             <div>신고하기</div>
           </Button>
         </div>
-        {isMobile && <div className="text-body-s text-grayscale-gray5">입양 후기・{data.date}</div>}
+        {isMobile && (
+          <div className="text-body-s text-grayscale-gray5">
+            {typeLabel}・{data.date}
+          </div>
+        )}
         <div className="font-medium text-body-m text-primary-500 break-all">{data.content}</div>
       </div>
       <ReportDialog open={isReportDialogOpen} onOpenChange={setIsReportDialogOpen} type="review" reviewId={data.id} />

--- a/src/app/(main)/explore/breeder/[id]/_components/reviews.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/reviews.tsx
@@ -6,7 +6,7 @@ import BreederProfileSectionTitle from '@/components/breeder-profile/breeder-pro
 import Review from './review';
 
 interface ReviewsProps {
-  data: { id: string; nickname: string; date: string; content: string }[];
+  data: { id: string; nickname: string; date: string; content: string; reviewType?: string }[];
   breederId: string;
 }
 

--- a/src/app/(main)/explore/breeder/[id]/page.tsx
+++ b/src/app/(main)/explore/breeder/[id]/page.tsx
@@ -236,6 +236,7 @@ export default function Page({ params }: PageProps) {
     content: string;
     writtenAt?: string;
     createdAt?: string;
+    reviewType?: string;
   };
 
   // 프로필 데이터 매핑
@@ -326,6 +327,12 @@ export default function Page({ params }: PageProps) {
 
   // 후기 매핑
   const reviews = ((reviewsData?.items || []) as ReviewItem[]).map((review) => {
+    const typeMap: Record<string, string> = {
+      consultation: '상담 후기',
+      adoption: '입양 후기',
+      adoption_completed: '입양 후기',
+    };
+
     // 날짜 필드: 백엔드에서 writtenAt을 반환
     const dateString = review.writtenAt || review.createdAt;
     let formattedDate = '';
@@ -347,6 +354,7 @@ export default function Page({ params }: PageProps) {
       nickname: review.adopterName || review.adopterNickname || '익명',
       date: formattedDate || '날짜 없음',
       content: review.content,
+      reviewType: typeMap[review.reviewType || ''] || '상담 후기',
     };
   });
 


### PR DESCRIPTION
### 작업 내용


## 브리더 프로필 후기의 타입(상담/입양) 표시를 실제 데이터에 맞게 수정
- 후기 매핑 시 reviewType을 한글 라벨로 변환(상담 후기/입양 후기)
- 리뷰 리스트/아이템 컴포넌트가 타입 라벨을 표시하도록 업데이트

