### PR TITLE
fix : 브리더 프로필 아바타 표시 수정

### DIFF
--- a/src/app/(main)/explore/_components/site-breeder-list.tsx
+++ b/src/app/(main)/explore/_components/site-breeder-list.tsx
@@ -89,7 +89,7 @@ export default function SiteBreederList() {
               <Breeder>
                 <BreederProfile>
                   <BreederHeader>
-                    <BreederAvatar src={breeder.profileImage} />
+                    <BreederAvatar src={breeder.profileImage} animal={(breeder.petType as 'cat' | 'dog') || petType} />
                     <div className="flex items-center gap-2">
                       <BreederName>{breeder.breederName}</BreederName>
                       <LevelBadge level={breeder.breederLevel as 'elite' | 'new'} />

--- a/src/app/(main)/explore/breeder/[id]/_components/breeder-profile.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/breeder-profile.tsx
@@ -51,7 +51,7 @@ export default function BreederProfile({
     <div className="flex flex-col gap-4 lg:w-51">
       <div className="flex gap-4 lg:flex-col lg:gap-8">
         <div className="w-[8.25rem] h-[8.25rem] md:w-[10rem] md:h-[10rem] lg:w-[12.75rem] lg:h-[12.75rem] rounded-lg overflow-hidden shrink-0 bg-grayscale-gray1 flex items-center justify-center">
-          {avatarUrl ? (
+          {avatarUrl && avatarUrl !== '/profile-empty.svg' ? (
             <Image
               src={avatarUrl}
               alt={nickname}
@@ -61,7 +61,7 @@ export default function BreederProfile({
               unoptimized={avatarUrl.startsWith('http')}
             />
           ) : (
-            <IconComponent className="w-[9.5625rem] h-[9.5625rem] text-grayscale-gray5" />
+            <IconComponent className="w-[6.1875rem] h-[6.1875rem] md:w-[7.5rem] md:h-[7.5rem] lg:w-[9.5625rem] lg:h-[9.5625rem] text-grayscale-gray5" />
           )}
         </div>
         <div className="flex-1 space-y-4 flex flex-col md:justify-between">

--- a/src/app/(main)/explore/breeder/[id]/page.tsx
+++ b/src/app/(main)/explore/breeder/[id]/page.tsx
@@ -205,6 +205,9 @@ export default function Page({ params }: PageProps) {
     breeds?: string[];
     representativePhotos?: string[];
     description?: string;
+    petType?: 'dog' | 'cat';
+    specialization?: string[];
+    specializationTypes?: string[];
   };
 
   type BreederPetItem = {
@@ -267,6 +270,11 @@ export default function Page({ params }: PageProps) {
   const locationFromApi = apiData.location || locationStr;
   const levelFromApi = apiData.breederLevel === 'elite' ? 'elite' : 'new';
 
+  // 고양이/강아지 타입 판별
+  const specialization =
+    apiData.specialization || apiData.specializationTypes || profileInfo?.specializationAreas || [];
+  const animalType = apiData.petType || (specialization.includes('cat') ? 'cat' : 'dog');
+
   const breederProfileData = {
     avatarUrl,
     nickname: profileData.breederName,
@@ -274,7 +282,7 @@ export default function Page({ params }: PageProps) {
     location: locationFromApi,
     priceRange: priceRangeStr,
     breeds: apiData.breeds || profileInfo?.specializationAreas || [],
-    animal: 'dog' as const,
+    animal: animalType as 'cat' | 'dog',
   };
 
   // 환경 사진 - API 응답 구조에 맞게 처리

--- a/src/components/breeder-list/breeder-avatar.tsx
+++ b/src/components/breeder-list/breeder-avatar.tsx
@@ -13,9 +13,9 @@ export default function BreederAvatar({ src, animal = 'dog' }: BreederAvatarProp
       {src && <AvatarImage src={src} />}
       <AvatarFallback>
         {animal === 'cat' ? (
-          <Cat className="size-9 text-grayscale-gray5" />
+          <Cat className="w-[6.1875rem] h-[6.1875rem] md:w-[7.5rem] md:h-[7.5rem] lg:size-9 text-grayscale-gray5" />
         ) : (
-          <Dog className="size-9 text-grayscale-gray5" />
+          <Dog className="w-[6.1875rem] h-[6.1875rem] md:w-[7.5rem] md:h-[7.5rem] lg:size-9 text-grayscale-gray5" />
         )}
       </AvatarFallback>
     </Avatar>


### PR DESCRIPTION
### 작업 내용


### 주요 변경
- 브리더 프로필 이미지가 없을 때 동물 타입(cat/dog)에 맞는 아이콘 표시
- 아바타 아이콘 크기 반응형 조정 (모바일/패드/데스크탑)
- explore 페이지와 프로필 상세 페이지 모두에 적용



##. 브리더 아바타 아이콘 표시 개선
- **explore 페이지**: 프로필 이미지가 없을 때 `petType`에 따라 고양이/강아지 아이콘 표시
- **프로필 상세 페이지**: 프로필 이미지가 없거나 `/profile-empty.svg`일 때 `animal` 타입에 따라 아이콘 표시

##아바타 아이콘 크기 반응형 조정
- **모바일**: `w-[6.1875rem] h-[6.1875rem]`
- **패드 (md)**: `w-[7.5rem] h-[7.5rem]`
- **데스크탑 (lg)**: 기존 크기 유지
  - explore 페이지: `size-9` (기존)
  - 프로필 상세 페이지: `w-[9.5625rem] h-[9.5625rem]` (기존)



