### PR TITLE
feat :(상담 폼) 분양 중인 아이 팝업에서 상담 신청 시 개체 자동 선택 기능 추가

### DIFF
--- a/src/app/(main)/counselform/page.tsx
+++ b/src/app/(main)/counselform/page.tsx
@@ -13,7 +13,7 @@ import Arrow from '@/assets/icons/arrow';
 import SmallDot from '@/assets/icons/small-dot.svg';
 import { useForm, FormProvider, Controller, useWatch } from 'react-hook-form';
 import { useBreakpoint } from '@/hooks/use-breakpoint';
-import { useState, useEffect, Suspense } from 'react';
+import { useState, useEffect, useMemo, Suspense } from 'react';
 import { cn } from '@/lib/utils';
 import LeftArrow from '@/assets/icons/left-arrow.svg';
 import useNavigationGuard from '@/hooks/use-navigation-guard';
@@ -47,7 +47,10 @@ function CounselFormContent() {
   const { counselFormData, clearCounselFormData } = useCounselFormStore();
   const createApplicationMutation = useCreateApplication();
   const { data: breederPetsData } = useBreederPets(breederId);
-  const availablePets = breederPetsData?.items?.filter((pet) => pet.status === 'available') || [];
+  const availablePets = useMemo(
+    () => breederPetsData?.items?.filter((pet) => pet.status === 'available') || [],
+    [breederPetsData?.items],
+  );
   const [isIntroductionFocused, setIsIntroductionFocused] = useState(false);
   const [isLivingSpaceFocused, setIsLivingSpaceFocused] = useState(false);
   const [isPreviousPetsFocused, setIsPreviousPetsFocused] = useState(false);
@@ -83,6 +86,16 @@ function CounselFormContent() {
     defaultValues: defaultCounselValues,
     mode: 'onBlur',
   });
+
+  // petId가 있고 availablePets가 로드되면 해당 개체 선택
+  useEffect(() => {
+    if (petId && availablePets.length > 0 && !form.getValues('interestedAnimal')) {
+      const selectedPet = availablePets.find((pet) => pet.petId === petId);
+      if (selectedPet) {
+        form.setValue('interestedAnimal', selectedPet.name);
+      }
+    }
+  }, [petId, availablePets, form]);
 
   const formValues = useWatch({ control: form.control });
   const data = formValues || form.getValues();

--- a/src/app/(main)/explore/breeder/[id]/_components/pet-detail-dialog.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/pet-detail-dialog.tsx
@@ -81,7 +81,9 @@ export default function PetDetailDialog({
       return;
     }
     clearCounselFormData();
-    router.push(`/counselform?breederId=${breederId}`);
+    // type이 'pet'이고 pet이 있을 때만 petId 전달
+    const petIdParam = type === 'pet' && pet ? `&petId=${pet.id}` : '';
+    router.push(`/counselform?breederId=${breederId}${petIdParam}`);
     onOpenChange(false);
   };
 


### PR DESCRIPTION
### 작업 내용




## 분양 중인 아이 정보 팝업에서 상담 신청하기 버튼 클릭 시, 상담 폼에서 해당 개체가 자동으로 선택되도록 개선
- 상담 신청하기 버튼 클릭 시 `petId`를 URL 쿼리 파라미터로 전달
- `type === 'pet'`일 때만 `petId` 전달 (부모견은 제외)

## petId를 URL 쿼리 파라미터로 전달하여 개체 정보 연동
- URL에서 `petId` 쿼리 파라미터를 받아 처리
- `availablePets`가 로드되면 `petId`에 해당하는 개체를 찾아 `interestedAnimal` 필드에 자동 설정







