### PR TITLE
design : (홈) 모바일 환경일 때 사진 비율 1:1로 변경

### DIFF
--- a/src/app/(main)/_components/home-banner.tsx
+++ b/src/app/(main)/_components/home-banner.tsx
@@ -106,7 +106,7 @@ const HomeBanner = () => {
 
   if (isLoading) {
     return (
-      <div className="w-full h-[20rem] md:h-[380px] lg:h-[380px] flex items-center justify-center bg-gray-100 animate-pulse">
+      <div className="w-full aspect-square md:h-[380px] lg:aspect-[1919.21/380] flex items-center justify-center bg-gray-100 animate-pulse">
         <p className="text-body-m text-gray-400">배너 로딩 중...</p>
       </div>
     );
@@ -114,7 +114,7 @@ const HomeBanner = () => {
 
   if (error || banners.length === 0) {
     return (
-      <div className="w-full h-[20rem] md:h-[380px] lg:h-[380px] flex items-center justify-center bg-gray-50">
+      <div className="w-full aspect-square md:h-[380px] lg:aspect-[1919.21/380] flex items-center justify-center bg-gray-50">
         <p className="text-body-m text-gray-400">{error || '표시할 배너가 없습니다.'}</p>
       </div>
     );
@@ -128,7 +128,7 @@ const HomeBanner = () => {
   // 이미지 URL이 없으면 에러 UI 표시
   if (!currentImageUrl) {
     return (
-      <div className="w-full h-[20rem] md:h-[380px] lg:h-[380px] flex items-center justify-center bg-gray-50">
+      <div className="w-full aspect-square md:h-[380px] lg:aspect-[1919.21/380] flex items-center justify-center bg-gray-50">
         <p className="text-body-m text-gray-400">배너 이미지를 불러올 수 없습니다.</p>
       </div>
     );
@@ -158,7 +158,7 @@ const HomeBanner = () => {
   );
 
   return (
-    <div className="relative w-full h-[20rem] md:h-[380px] lg:h-[380px] overflow-hidden">
+    <div className="relative w-full aspect-square md:h-[380px] lg:aspect-[1919.21/380] overflow-hidden">
       {currentBanner.linkType === 'internal' ? (
         <Link href={currentBanner.linkUrl} className="block w-full h-full">
           {renderBannerContent()}


### PR DESCRIPTION
### 작업 내용

## (홈) 모바일 환경일 때 사진 비율 1:1로 변경



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 배너 레이아웃의 반응형 동작을 개선하였습니다. 고정 높이 기반의 컨테이너를 가로세로 비율 기반 레이아웃으로 변경하여 다양한 화면 크기에서 더 일관되고 부드러운 표시를 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->