### PR TITLE
design : (푸터) 카카오톡 아이콘 색상 변경

### DIFF
--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -33,7 +33,7 @@ export default function Footer() {
               className="cursor-pointer w-6 h-6 flex items-center justify-center hover:text-primary-500 active:text-primary-500 transition-colors group"
               aria-label="카카오톡 채널"
             >
-              <Kakao className="w-6 h-6 pointer-events-none group-hover:[&_path]:fill-[var(--color-primary-500)] group-active:[&_path]:fill-[var(--color-primary-500)]" />
+              <Kakao className="w-6 h-6 pointer-events-none [&_path]:fill-[var(--color-grayscale-gray5)] group-hover:[&_path]:fill-[var(--color-primary-500)] group-active:[&_path]:fill-[var(--color-primary-500)]" />
             </Link>
             <Link
               href="https://www.instagram.com/pawpong_official/"


### PR DESCRIPTION
### 작업 내용

## (푸터) 카카오톡 아이콘 색상 변경
- gray5으로 변경



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* 푸터의 카카오 SNS 아이콘 기본 색상을 그레이로 업데이트했습니다. 호버 및 활성 상태의 상호작용 색상은 유지됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->