### PR TITLE
fix : (GNB) 패드/모바일 환경에서 로그인 버튼 안보이도록 수정

### DIFF
--- a/src/components/gnb/gnb.tsx
+++ b/src/components/gnb/gnb.tsx
@@ -24,7 +24,7 @@ export default function Gnb({ variant = 'default', navVariant = 'breeder' }: Gnb
         <LogoButton />
         {isLg && <NavBar navVariant={navVariant} />}
         <div className="flex gap-4 items-center">
-          {user ? <NoticeButton /> : <LoginButton />}
+          {isLg && (user ? <NoticeButton /> : <LoginButton />)}
           {!isLg && <NavButton navVariant={navVariant} />}
         </div>
       </Container>

--- a/src/components/gnb/mobile-nav-header.tsx
+++ b/src/components/gnb/mobile-nav-header.tsx
@@ -4,15 +4,18 @@ import Logo from '@/assets/logo/logo';
 import { Button } from '../ui/button';
 import Link from 'next/link';
 import NoticeButton from './notice-button';
+import LoginButton from './login-button';
 import Close from '@/assets/icons/close';
 import { SheetClose } from '../ui/sheet';
 import { usePathname } from 'next/navigation';
 import { useNavigationGuardContext } from '@/contexts/navigation-guard-context';
+import { useAuthStore } from '@/stores/auth-store';
 import { MouseEvent } from 'react';
 
 export default function MobileNavHeader() {
   const pathname = usePathname();
   const guardContext = useNavigationGuardContext();
+  const { user } = useAuthStore();
 
   const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
     // Context가 없거나 홈 페이지면 기본 동작 허용
@@ -35,7 +38,7 @@ export default function MobileNavHeader() {
         </Link>
       </SheetClose>
       <div className="flex gap-4 items-center">
-        <NoticeButton />
+        {user ? <NoticeButton /> : <LoginButton />}
         <SheetClose asChild>
           <button className="flex items-center justify-center size-6">
             <Close className="size-5" />


### PR DESCRIPTION
### 작업 내용

## 패드/모바일 환경에서 로그인 버튼 안보이도록 수정
- 햄버거 버튼 클릭 시 열리는 메뉴 헤더로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 계정 관련 버튼이 큰 화면에서만 표시되도록 변경되었습니다.
  * 모바일 네비게이션이 로그인 상태에 따라 다른 버튼을 표시합니다. 로그인 시 알림 버튼, 미로그인 시 로그인 버튼이 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->