### PR TITLE
design : 상담폼 반응형 레이아웃 개선 및 인증번호 토스트 알림 UX 개선

### DIFF
--- a/src/app/(main)/counselform/page.tsx
+++ b/src/app/(main)/counselform/page.tsx
@@ -36,7 +36,7 @@ import useBrowserNavigationGuard from '@/hooks/use-browser-navigation-guard';
  * useSearchParams를 사용하므로 Suspense 경계 내에 있어야 함
  */
 function CounselFormContent() {
-  const isMdUp = useBreakpoint('md');
+  const isLgUp = useBreakpoint('lg');
   const { toast } = useToast();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -227,17 +227,17 @@ function CounselFormContent() {
           </button>
         </ExitConfirmDialog>
       </div>
-      <div className="min-h-screen flex w-full flex-col md:flex-row">
-        {/* 왼쪽 배너 영역: md 이상에서만 표시 */}
-        {isMdUp && (
-          <div className="md:w-[648px] md:pr-8 bg-tertiary-500">
-            <div className="md:h-[744px]">
+      <div className="min-h-screen flex w-full flex-col lg:flex-row">
+        {/* 왼쪽 배너 영역: lg 이상에서만 표시 */}
+        {isLgUp && (
+          <div className="lg:w-[648px] lg:pr-8 bg-tertiary-500">
+            <div className="lg:h-[744px]">
               <CounselBannerCarousel />
             </div>
           </div>
         )}
 
-        <div className="w-full md:w-1/2 flex flex-col">
+        <div className="w-full lg:w-1/2 flex flex-col">
           <div className="flex w-full flex-col items-center pb-20 md:pb-24  md:px-4 lg:px-0.5">
             <div className="flex flex-col gap-12 md:gap-8 w-full">
               {/* 개인정보 동의 섹션 */}

--- a/src/app/signup/_components/sections/user-info-section.tsx
+++ b/src/app/signup/_components/sections/user-info-section.tsx
@@ -26,6 +26,7 @@ import { useEffect, useState } from 'react';
 import PrivacyDialogTrigger from '../privacy-dialog-trigger';
 import TermDialogTrigger from '../term-dialog-trigger';
 import { useToast } from '@/hooks/use-toast';
+import { useBreakpoint } from '@/hooks/use-breakpoint';
 
 const messages: Array<{ type: 'success' | 'error'; text: string }> = [
   { type: 'success', text: '휴대폰 번호 인증을 성공했어요' },
@@ -67,6 +68,7 @@ const checkboxInfo: {
 export default function UserInfoSection() {
   const router = useRouter();
   const { toast } = useToast();
+  const isLg = useBreakpoint('lg'); // 왼쪽 배너 영역이 있는지 확인 (lg 이상에서만 표시)
   const agreements = useSignupFormStore((e) => e.agreements);
   const setAgreements = useSignupFormStore((e) => e.setAgreements);
   const age14Checked = useSignupFormStore((e) => e.age14Checked);
@@ -118,9 +120,8 @@ export default function UserInfoSection() {
       setTimerActive(true); // 타이머 시작
       setTimeLeft(180); // 3분 초기화
       toast({
-        title: '인증번호 발송 완료',
-        description: '휴대폰으로 인증번호를 발송했습니다.',
-        position: 'split',
+        description: '인증 번호가 발송되었습니다',
+        position: isLg ? 'split' : 'default', // 왼쪽 영역 있을 때: split, 없을 때: default
       });
     } catch (error) {
       // API 에러 메시지 파싱

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -44,7 +44,7 @@ const Toast = React.forwardRef<
     <ToastPrimitives.Root
       ref={ref}
       className={cn(
-        'group pointer-events-auto relative flex w-full items-center justify-between gap-1 rounded-full bg-[#4f3b2e] px-4 py-[10px] pr-2 shadow-[0px_0px_13px_0px_rgba(12,17,29,0.08)] transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
+        'group pointer-events-auto relative flex w-full items-center justify-between gap-1 rounded-full bg-[#4f3b2e] px-4 py-[10px] pr-2 shadow-[0px_0px_13px_0px_rgba(12,17,29,0.08)] transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-bottom-full data-[state=open]:slide-in-from-bottom-full',
         className,
       )}
       {...props}

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -149,7 +149,7 @@ function toast({ position = 'default', ...props }: Toast) {
       id,
       position,
       open: true,
-      duration: props.duration ?? 2000, // 기본 2초 후 자동으로 사라짐
+      duration: props.duration ?? 5000, // 기본 5초 후 자동으로 사라짐
       onOpenChange: (open) => {
         if (!open) dismiss();
       },


### PR DESCRIPTION
### 작업 내용


## 상담폼 페이지 반응형 레이아웃 조정
  - 왼쪽 배너 표시 조건을 `md` (768px) → `lg` (1280px) 브레이크포인트로 변경

## 토스트 알림 UX 개선
  - 토스트 기본 표시 시간 2초 → 5초로 연장
  - 토스트 애니메이션 방향 변경 (하단에서 나타나고 사라지도록)
  - 회원가입 페이지에서 화면 크기에 따라 토스트 위치 자동 조정 (`split` / `default`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **개선 사항**
  * 큰 화면에서의 레이아웃 반응성이 개선되어 더 나은 사용자 경험을 제공합니다.
  * 알림 메시지가 자동으로 사라지는 시간을 2초에서 5초로 연장하여 사용자가 알림을 더 오래 확인할 수 있습니다.
  * 알림 메시지 애니메이션 방향이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->