### PR TITLE
feat : 부모 동물/분양 중인 아이들 개수 제한 제거

### DIFF
--- a/src/app/(main)/_components/home-breeder-grid.tsx
+++ b/src/app/(main)/_components/home-breeder-grid.tsx
@@ -3,7 +3,6 @@
 import AnimalProfile from '@/app/(main)/explore/breeder/[id]/_components/animal-profile';
 import Link from 'next/link';
 import LoadMoreButton from '@/components/ui/load-more-button';
-
 import BreederProfileSectionHeader from '@/components/breeder-profile/breeder-profile-section-header';
 import BreederProfileSectionTitle from '@/components/breeder-profile/breeder-profile-section-title';
 import { useHomeAnimals } from '../_hooks/use-home-animals';

--- a/src/app/(main)/explore/breeder/[id]/_components/animal-profile.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/animal-profile.tsx
@@ -58,7 +58,7 @@ export default function AnimalProfile({
           </div>
         )}
       </div>
-      <div className="space-y-3 mt-3">
+      <div className="space-y-3 mt-4">
         <div className="gap-1.5 flex flex-col">
           <div className="flex items-center gap-1.5">
             <div className="text-body-m font-semibold text-primary-500">{name}</div>

--- a/src/app/(main)/explore/breeder/[id]/_components/breeding-animals.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/breeding-animals.tsx
@@ -85,11 +85,11 @@ export default function BreedingAnimals({
     <BreederProfileSection>
       <BreederProfileSectionHeader>
         <BreederProfileSectionTitle>분양 중인 아이들</BreederProfileSectionTitle>
-        {data.length > 3 ? (
+        {data.length > 3 && (
           <div onClick={handleMoreClick}>
             <BreederProfileSectionMore />
           </div>
-        ) : null}
+        )}
       </BreederProfileSectionHeader>
       {data.length === 0 ? (
         <EmptyPetState />

--- a/src/app/(main)/explore/breeder/[id]/_components/parents.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/parents.tsx
@@ -57,11 +57,11 @@ export default function Parents({
     <BreederProfileSection>
       <BreederProfileSectionHeader>
         <BreederProfileSectionTitle>엄마 · 아빠</BreederProfileSectionTitle>
-        {data.length > 1 ? (
+        {data.length > 3 && (
           <div onClick={handleMoreClick}>
             <BreederProfileSectionMore />
           </div>
-        ) : null}
+        )}
       </BreederProfileSectionHeader>
       {data.length === 0 ? (
         <EmptyPetState />

--- a/src/app/(main)/explore/breeder/[id]/parents/page.tsx
+++ b/src/app/(main)/explore/breeder/[id]/parents/page.tsx
@@ -114,7 +114,7 @@ export default function ParentsPage({ params }: PageProps) {
             </div>
           ) : (
             <div className="w-full flex flex-col items-center gap-10 md:gap-[60px] lg:gap-20">
-              <div className="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+              <div className="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-x-6 gap-y-20">
                 {allParentPets.map((parent) => (
                   <AnimalProfile key={parent.id} data={parent} onClick={() => handlePetClick(parent)} />
                 ))}

--- a/src/app/(main)/explore/breeder/[id]/pets/page.tsx
+++ b/src/app/(main)/explore/breeder/[id]/pets/page.tsx
@@ -147,7 +147,7 @@ export default function PetsPage({ params }: PageProps) {
             </div>
           ) : (
             <div className="w-full flex flex-col items-center gap-10 md:gap-[60px] lg:gap-20">
-              <div className="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+              <div className="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-x-6 gap-y-20">
                 {allPets.map((pet) => (
                   <AnimalProfile key={pet.id} data={pet} onClick={() => handlePetClick(pet)} />
                 ))}

--- a/src/app/(main)/profile/_components/breeding-animals.tsx
+++ b/src/app/(main)/profile/_components/breeding-animals.tsx
@@ -58,10 +58,7 @@ export default function BreedingAnimals({ form }: { form: ReturnType<typeof useF
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const MAX_ANIMALS = 6;
-
   const addAnimal = () => {
-    if (fields.length >= MAX_ANIMALS) return;
     append({
       id: `animal-${Date.now()}-${Math.random()}`,
       name: '',
@@ -606,20 +603,18 @@ export default function BreedingAnimals({ form }: { form: ReturnType<typeof useF
       </div>
 
       {/* 추가하기 버튼 */}
-      {fields.length < MAX_ANIMALS && (
-        <Button
-          onClick={addAnimal}
-          variant="addParent"
-          className="bg-tertiary-700 flex gap-1 items-center overflow-hidden pl-3 pr-5 py-2.5 relative rounded-full shrink-0"
-        >
-          <div className="overflow-hidden relative shrink-0 size-7 flex items-center justify-center">
-            <Plus />
-          </div>
-          <p className="font-medium leading-body-s relative shrink-0 text-grayscale-gray6 text-body-s text-center text-nowrap">
-            추가하기
-          </p>
-        </Button>
-      )}
+      <Button
+        onClick={addAnimal}
+        variant="addParent"
+        className="bg-tertiary-700 flex gap-1 items-center overflow-hidden pl-3 pr-5 py-2.5 relative rounded-full shrink-0"
+      >
+        <div className="overflow-hidden relative shrink-0 size-7 flex items-center justify-center">
+          <Plus />
+        </div>
+        <p className="font-medium leading-body-s relative shrink-0 text-grayscale-gray6 text-body-s text-center text-nowrap">
+          추가하기
+        </p>
+      </Button>
     </div>
   );
 }

--- a/src/app/(main)/profile/_components/parents-info.tsx
+++ b/src/app/(main)/profile/_components/parents-info.tsx
@@ -25,10 +25,8 @@ import { BREEDER_PROFILE_ERROR } from '@/constants/errors/breeder-profile-error'
 
 export default function ParentsInfo({
   form,
-  maxParents,
 }: {
   form: ReturnType<typeof useFormContext<ProfileFormData>>;
-  maxParents?: number;
 }) {
   const { control, watch, formState, getValues, setValue } = form;
   const { errors } = formState;
@@ -54,10 +52,7 @@ export default function ParentsInfo({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const MAX_PARENTS = maxParents ?? 100;
-
   const addParent = () => {
-    if (fields.length >= MAX_PARENTS) return;
     append({
       id: `parent-${Date.now()}-${Math.random()}`,
       name: '',
@@ -349,12 +344,11 @@ export default function ParentsInfo({
       </div>
 
       {/* 추가하기 버튼 */}
-      {fields.length < MAX_PARENTS && (
-        <Button
-          onClick={addParent}
-          variant="addParent"
-          className="bg-tertiary-700 flex gap-1 items-center overflow-hidden pl-3 pr-5 py-2.5 relative rounded-full shrink-0"
-        >
+      <Button
+        onClick={addParent}
+        variant="addParent"
+        className="bg-tertiary-700 flex gap-1 items-center overflow-hidden pl-3 pr-5 py-2.5 relative rounded-full shrink-0"
+      >
           <div className="overflow-hidden relative shrink-0 size-7 flex items-center justify-center">
             <Plus />
           </div>
@@ -362,7 +356,6 @@ export default function ParentsInfo({
             추가하기
           </p>
         </Button>
-      )}
     </div>
   );
 }

--- a/src/app/(main)/profile/page.tsx
+++ b/src/app/(main)/profile/page.tsx
@@ -541,7 +541,7 @@ export default function ProfilePage() {
               animal={animalType}
             />
             {/* 엄마 아빠 정보 */}
-            <ParentsInfo form={form} maxParents={apiProfileData?.verificationInfo?.plan === 'basic' ? 4 : undefined} />
+            <ParentsInfo form={form} />
             {/* 분양 중인 아이 */}
             <BreedingAnimals form={form} />
             {/* 탈퇴하기 링크 */}


### PR DESCRIPTION
### 작업 내용



##  부모 동물/분양 중인 아이들 개수 제한 제거
- 프로필 페이지에서 부모 동물과 분양 중인 아이들 무제한 업로드 가능
- `MAX_ANIMALS = 6` 제한 제거
- `MAX_PARENTS` 제한 제거

## UI 개선

- 더보기 버튼 조건부 표시: 3개 초과일 때만 헤더 오른쪽에 더보기 버튼 표시
- 그리드 레이아웃 개선: 첫 줄과 두 번째 줄 사이 간격 5rem으로 조정
- 간격 조정: 사진과 이름 사이 간격 `mt-3` → `mt-4`로 변경






### 연관 이슈

#330 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 기능
- 프로필에서 추가할 수 있는 동물 개수 제한 제거
- 프로필에서 추가할 수 있는 부모 정보 개수 제한 제거  
- "더보기" 버튼 표시 조건 개선

## 스타일
- 동물 프로필 및 그리드 페이지 간격 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->