### PR TITLE
feat : (설정) 브리더 상담 신청 알림톡 수신 동의 UI 추가

### DIFF
--- a/src/app/(main)/settings/_components/email-settings-section.tsx
+++ b/src/app/(main)/settings/_components/email-settings-section.tsx
@@ -5,12 +5,38 @@ import { Switch } from '@/components/ui/switch';
 interface EmailSettingsSectionProps {
   marketingAgreed: boolean;
   onMarketingAgreedChange: (checked: boolean) => void;
+  isBreeder?: boolean;
+  consultationAgreed?: boolean;
+  onConsultationAgreedChange?: (checked: boolean) => void;
 }
 
-export default function EmailSettingsSection({ marketingAgreed, onMarketingAgreedChange }: EmailSettingsSectionProps) {
+export default function EmailSettingsSection({
+  marketingAgreed,
+  onMarketingAgreedChange,
+  isBreeder = false,
+  consultationAgreed = false,
+  onConsultationAgreedChange,
+}: EmailSettingsSectionProps) {
   return (
     <div className="flex flex-col gap-5 w-full">
-      <h3 className="text-body-s font-medium text-grayscale-gray5">이메일 수신 설정</h3>
+      <h3 className="text-body-s font-medium text-grayscale-gray5">알림 수신 설정</h3>
+      {/* {isBreeder && (
+        <>
+          <div className="flex flex-col gap-[0.62rem] w-full">
+            <div className="flex items-center justify-between gap-3 w-full">
+              <span className="text-body-s font-medium text-grayscale-gray6">상담 신청 알림톡 수신 동의</span>
+              <Switch
+                checked={consultationAgreed}
+                onCheckedChange={onConsultationAgreedChange}
+                className="data-[state=checked]:bg-primary-500 data-[state=checked]:border-primary-500"
+              />
+            </div>
+            <p className="text-caption font-medium text-grayscale-gray5">
+              입양 상담이 도착하면 카카오톡으로 바로 알려드릴게요
+            </p>
+          </div>
+        </>
+      )} */}
       <div className="flex items-center justify-between gap-3 w-full">
         <span className="text-body-s font-medium text-grayscale-gray6">광고성 정보 수신 동의</span>
         <Switch

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -18,6 +18,7 @@ export default function SettingsPage() {
   const { isLoading: isAuthLoading } = useAuthGuard();
   const { user, clearAuth } = useAuthStore();
   const [marketingAgreed, setMarketingAgreed] = useState(false);
+  const [consultationAgreed, setConsultationAgreed] = useState(false);
   const [nickname, setNickname] = useState('');
   const [email, setEmail] = useState('');
   const [provider, setProvider] = useState<'local' | 'kakao' | 'google' | 'naver' | 'apple'>('kakao');
@@ -43,6 +44,10 @@ export default function SettingsPage() {
           if (profile.marketingAgreed !== undefined) {
             setMarketingAgreed(profile.marketingAgreed);
           }
+          // TODO: 상담 신청 알림톡 수신 동의 상태 로드 (API 연동 필요)
+          // if (profile.consultationAgreed !== undefined) {
+          //   setConsultationAgreed(profile.consultationAgreed);
+          // }
         } else {
           // 입양자 프로필 로드
           const profile = await getAdopterProfile();
@@ -114,6 +119,27 @@ export default function SettingsPage() {
       toast({
         title: checked ? '마케팅 수신 동의' : '마케팅 수신 거부',
         description: checked ? '광고성 정보 수신에 동의하셨습니다.' : '광고성 정보 수신을 거부하셨습니다.',
+        position: 'default',
+      });
+    } catch (error) {
+      toast({
+        title: '설정 변경 실패',
+        description: error instanceof Error ? error.message : '다시 시도해주세요.',
+        position: 'default',
+      });
+    }
+  };
+
+  const handleConsultationAgreedChange = async (checked: boolean) => {
+    if (!user) return;
+
+    try {
+      // TODO: 브리더 상담 신청 알림톡 수신 동의 변경 API 호출 (API 연동 필요)
+      // await updateBreederProfile({ consultationAgreed: checked });
+      setConsultationAgreed(checked);
+      toast({
+        title: checked ? '상담 신청 알림톡 수신 동의' : '상담 신청 알림톡 수신 거부',
+        description: checked ? '상담 신청 알림톡 수신에 동의하셨습니다.' : '상담 신청 알림톡 수신을 거부하셨습니다.',
         position: 'default',
       });
     } catch (error) {
@@ -212,6 +238,9 @@ export default function SettingsPage() {
           <EmailSettingsSection
             marketingAgreed={marketingAgreed}
             onMarketingAgreedChange={handleMarketingAgreedChange}
+            // isBreeder={user?.role === 'breeder'}
+            // consultationAgreed={consultationAgreed}
+            // onConsultationAgreedChange={handleConsultationAgreedChange}
           />
         </div>
 


### PR DESCRIPTION
## 변경 사항
## 브리더 상담 신청 알림톡 수신 동의 UI 추가
- 설정 페이지: 브리더용 상담 신청 알림톡 수신 동의 기능 준비 (현재 주석 처리, API 연동 대기 중)
  - `EmailSettingsSection` 컴포넌트에 브리더 전용 props 추가
  - 설정 페이지에 상담 신청 알림톡 수신 동의 상태 관리 로직 추가
  - 알림 수신 설정 섹션 제목 변경 ("이메일 수신 설정" → "알림 수신 설정")

## 관련 이슈
 #333



