### PR TITLE
feat : (브리더 프로필) 후기 '더보기'버튼을 '관리'버튼으로 변경

### DIFF
--- a/src/app/(main)/explore/breeder/[id]/_components/breeder-detail-client.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/breeder-detail-client.tsx
@@ -394,7 +394,7 @@ export default function BreederDetailClient({ breederId }: BreederDetailClientPr
             />
           )}
 
-          {!isReviewsLoading && reviews.length > 0 && <Reviews data={reviews} breederId={breederId} />}
+          {!isReviewsLoading && reviews.length > 0 && <Reviews data={reviews} breederId={breederId} isOwnProfile={isOwnProfile} />}
         </div>
       </div>
       {!isLg && (

--- a/src/app/(main)/explore/breeder/[id]/_components/reviews.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/reviews.tsx
@@ -4,13 +4,16 @@ import BreederProfileSectionHeader from '@/components/breeder-profile/breeder-pr
 import BreederProfileSectionMore from '@/components/breeder-profile/breeder-profile-section-more';
 import BreederProfileSectionTitle from '@/components/breeder-profile/breeder-profile-section-title';
 import Review from './review';
+import { Button } from '@/components/ui/button';
+import Pencil from '@/assets/icons/pencil.svg';
 
 interface ReviewsProps {
   data: { id: string; nickname: string; date: string; content: string; reviewType?: string }[];
   breederId: string;
+  isOwnProfile?: boolean;
 }
 
-export default function Reviews({ data, breederId }: ReviewsProps) {
+export default function Reviews({ data, breederId, isOwnProfile = false }: ReviewsProps) {
   const displayedReviews = data.slice(0, 5);
 
   return (
@@ -18,9 +21,24 @@ export default function Reviews({ data, breederId }: ReviewsProps) {
       <BreederProfileSectionHeader>
         <BreederProfileSectionTitle>후기</BreederProfileSectionTitle>
         {data.length > 5 && (
-          <Link href={`/explore/breeder/${breederId}/reviews`}>
-            <BreederProfileSectionMore />
-          </Link>
+          <>
+            {isOwnProfile ? (
+              <Link href="/profile/reviews">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="gap-1 has-[>svg]:px-0 text-body-xs font-medium text-secondary-700"
+                >
+                  <div>관리</div>
+                  <Pencil  />
+                </Button>
+              </Link>
+            ) : (
+              <Link href={`/explore/breeder/${breederId}/reviews`}>
+                <BreederProfileSectionMore />
+              </Link>
+            )}
+          </>
         )}
       </BreederProfileSectionHeader>
       <div className="flex flex-col gap-8 ">


### PR DESCRIPTION
### 작업 내용
## 후기 '더보기'버튼을 '관리'버튼으로 변경
- 브리더 본인일 때만 "더보기"를 "관리"로 변경
- pencil 아이콘 추가 (gap-1)
- 브리더 본인일 때 /profile/reviews로 이동
- 브리더 본인이 아닐 때는 기존 "더보기" 버튼이 표시

### 연관 이슈
#346 
