### PR TITLE
feat : (후기 관리) 더보기 버튼 추가

### DIFF
--- a/src/app/(main)/explore/breeder/[id]/reviews/page.tsx
+++ b/src/app/(main)/explore/breeder/[id]/reviews/page.tsx
@@ -5,6 +5,7 @@ import Header from '../../_components/header';
 import Review from '../_components/review';
 import { useBreederProfile, useBreederReviewsInfinite } from '../_hooks/use-breeder-detail';
 import LoadMoreButton from '@/components/ui/load-more-button';
+import { formatDateToDotNotation } from '@/utils/date-utils';
 
 interface PageProps {
   params: Promise<{
@@ -35,7 +36,7 @@ export default function ReviewsPage({ params }: PageProps) {
           createdAt: string;
           writtenAt?: string;
           content: string;
-          type?: string; // 백엔드 API가 type으로 반환
+          type?: string; 
         }) => {
           const typeMap: Record<string, string> = {
             consultation: '상담 후기',
@@ -45,16 +46,7 @@ export default function ReviewsPage({ params }: PageProps) {
 
           // 날짜 필드: 백엔드에서 writtenAt을 반환
           const dateString = review.writtenAt || review.createdAt;
-          let formattedDate = '';
-
-          if (dateString) {
-            try {
-              const date = new Date(dateString);
-              formattedDate = date.toLocaleDateString('ko-KR');
-            } catch {
-              formattedDate = '날짜 없음';
-            }
-          }
+          const formattedDate = formatDateToDotNotation(dateString);
 
           return {
             id: review.reviewId,
@@ -65,9 +57,6 @@ export default function ReviewsPage({ params }: PageProps) {
           };
         },
       ) || [];
-
-  // 첫 페이지의 총 개수 확인 (더보기 버튼 표시 여부 결정용)
-  const firstPageCount = reviewsData?.pages[0]?.items?.length || 0;
 
   return (
     <>
@@ -89,17 +78,20 @@ export default function ReviewsPage({ params }: PageProps) {
               <p className="text-body-s text-grayscale-gray5">등록된 후기가 없습니다.</p>
             </div>
           ) : (
-            <div className="w-full flex flex-col items-center gap-10 md:gap-[60px] lg:gap-20">
+            <>
+              {/* 후기 리스트 */}
               <div className="w-full flex flex-col gap-8">
                 {allReviews.map((review) => (
                   <Review key={review.id} data={review} />
                 ))}
               </div>
-              {/* 더보기 버튼 - 첫 페이지가 10개 이상이고 다음 페이지가 있을 때만 표시 */}
-              {firstPageCount >= 10 && hasNextPage && (
-                <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} />
+              {/* 더보기 버튼 - 후기가 3개 이상이고 다음 페이지가 있을 때만 표시 */}
+              {allReviews.length >= 3 && hasNextPage && (
+                <div className="mt-20">
+                  <LoadMoreButton onClick={() => fetchNextPage()} isLoading={isFetchingNextPage} />
+                </div>
               )}
-            </div>
+            </>
           )}
         </div>
       </div>

--- a/src/app/(main)/profile/reviews/_components/review-list-item.tsx
+++ b/src/app/(main)/profile/reviews/_components/review-list-item.tsx
@@ -60,8 +60,8 @@ export default function ReviewListItem({ review }: ReviewListItemProps) {
     console.log('답글 제출:', review.reviewId, replyText);
     if (replyText.trim()) {
       setSubmittedReply(replyText);
-      setIsReplying(false);
-      setReplyText('');
+    setIsReplying(false);
+    setReplyText('');
     }
   };
 

--- a/src/app/(main)/profile/reviews/page.tsx
+++ b/src/app/(main)/profile/reviews/page.tsx
@@ -10,6 +10,7 @@ import { useAuthStore } from '@/stores/auth-store';
 import { useBreederReviewsInfinite } from '@/app/(main)/explore/breeder/[id]/_hooks/use-breeder-detail';
 import EmptyReviewsState from './_components/empty-reviews-state';
 import ReviewListItem from './_components/review-list-item';
+import { formatDateToDotNotation } from '@/utils/date-utils';
 
 const PAGE_SIZE = 10;
 
@@ -55,16 +56,7 @@ export default function ReviewsPage() {
 
           // 날짜 필드: 백엔드에서 writtenAt을 반환
           const dateString = review.writtenAt || review.createdAt;
-          let formattedDate = '';
-
-          if (dateString) {
-            try {
-              const date = new Date(dateString);
-              formattedDate = date.toLocaleDateString('ko-KR');
-            } catch {
-              formattedDate = '날짜 없음';
-            }
-          }
+          const formattedDate = formatDateToDotNotation(dateString);
 
           return {
             reviewId: review.reviewId,
@@ -123,6 +115,7 @@ export default function ReviewsPage() {
           <EmptyReviewsState />
         ) : (
           <>
+            {/* 후기 리스트 */}
             <div className="flex flex-col gap-7">
               {allReviews.map((review, index) => (
                 <div key={review.reviewId} className="flex flex-col">
@@ -132,13 +125,11 @@ export default function ReviewsPage() {
               ))}
             </div>
 
-            {/* 더보기 버튼 */}
-            {hasNextPage && (
-              <LoadMoreButton
-                onClick={handleLoadMore}
-                isLoading={isFetchingNextPage}
-                wrapperClassName="pb-20 lg:pb-24"
-              />
+            {/* 더보기 버튼 - 후기가 10개 이상이면 표시 */}
+            {allReviews.length >= 10 && (
+              <div className="mt-4 md:mt-9 lg:mt-10 pb-20 lg:pb-24">
+                <LoadMoreButton onClick={handleLoadMore} isLoading={isFetchingNextPage} disabled={!hasNextPage} />
+              </div>
             )}
           </>
         )}


### PR DESCRIPTION
### 작업 내용



## 브리더 프로필 후기 섹션 개선
- 브리더 본인일 때 "더보기" 버튼을 "관리" 버튼으로 변경
- Pencil 아이콘 추가 및 스타일 적용
- 브리더 본인일 때 `/profile/reviews`로 이동하도록 변경

## 후기 페이지 더보기 버튼 추가
- `/profile/reviews` 페이지에 더보기 버튼 추가
- `/explore/breeder/[id]/reviews` 페이지에 더보기 버튼 추가
- 조건: 후기 10개 이상일 때 표시
- 반응형 여백 적용
  - 모바일: 40px (gap-6 + mt-4)
  - 태블릿: 60px (gap-6 + md:mt-9)
  - 데스크탑: 80px (lg:gap-10 + lg:mt-10)

## 날짜 포맷팅 로직 리팩토링
- 중복된 날짜 포맷팅 로직을 `formatDateToDotNotation` 유틸 함수로 통합
- `/profile/reviews/page.tsx` 및 `/explore/breeder/[id]/reviews/page.tsx`에 적용
- "YYYY. MM. DD." 형식으로 일관성 있게 표시


### 연관 이슈
 #346


