### PR TITLE
style : 다이얼로그 헤더 스타일 통일, fix : addition-message 섹션 제거

### DIFF
--- a/src/app/(main)/application/_components/review/review-dialog.tsx
+++ b/src/app/(main)/application/_components/review/review-dialog.tsx
@@ -6,6 +6,7 @@ import { Dialog, DialogContent, DialogTrigger, DialogTitle } from '@/components/
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { Button } from '@/components/ui/button';
 import ReviewWriteDialog from './review-write-dialog';
+import ReviewHeader from './review-header';
 import { getApplicationDetail } from '@/api/application';
 import { getAdopterProfile } from '@/api/adopter';
 import { Separator } from '@/components/ui/separator';
@@ -86,10 +87,14 @@ export default function ReviewDialog({
         <DialogTrigger asChild>{children}</DialogTrigger>
         <DialogContent
           className={`${dialogContentClass} p-0 gap-0 bg-white flex flex-col`}
+          showCloseButton={false}
         >
           <VisuallyHidden>
             <DialogTitle>신청 내역 상세</DialogTitle>
           </VisuallyHidden>
+
+          {/* 헤더 - 닫기 버튼 */}
+          <ReviewHeader onClose={() => setOpen(false)} />
 
           {/* 상단 구분선 */}
           <Separator className="bg-grayscale-gray2" />

--- a/src/app/(main)/application/_components/review/review-header.tsx
+++ b/src/app/(main)/application/_components/review/review-header.tsx
@@ -10,7 +10,7 @@ interface ReviewHeaderProps {
 
 export default function ReviewHeader({ onClose }: ReviewHeaderProps) {
   return (
-    <div className="flex flex-col gap-[10px] items-start pt-6 px-5 pb-[10px] md:pt-6 md:px-6 md:pb-[10px] shrink-0">
+    <div className="bg-white flex flex-col gap-[10px] items-start pt-6 px-5 pb-[10px] md:pt-6 md:px-6 md:pb-[10px] shrink-0 rounded-t-none md:rounded-t-2xl">
       <div className="flex gap-1 items-center justify-end w-full">
         <DialogClose asChild>
           <Button variant="secondary" size="icon" onClick={onClose}>

--- a/src/app/(main)/modify-counselform/_components/counsel-form-content.tsx
+++ b/src/app/(main)/modify-counselform/_components/counsel-form-content.tsx
@@ -93,9 +93,8 @@ function CounselFormContentInner() {
       <FormLayout hasFormData={hasFormData} isLgUp={isLgUp}>
         <div className="w-full lg:w-1/2 flex flex-col">
           <div className="flex w-full flex-col items-center pb-20 md:pb-24  md:px-4 lg:px-0.5">
-            {COUNSEL_SECTIONS.filter((section) => section.sectionId !== 'additional-message').map(
-              (section, index, filteredSections) => {
-                const isLast = index === filteredSections.length - 1;
+            {COUNSEL_SECTIONS.map((section, index) => {
+              const isLast = index === COUNSEL_SECTIONS.length - 1;
 
                 return (
                   <div key={section.sectionId} className="w-full">


### PR DESCRIPTION
### 작업 내용




## 다이얼로그 헤더 개선
- `review-dialog.tsx`와 `application-detail-modal.tsx`에서 `ReviewHeader` 사용


## 상담폼 수정 페이지 개선
- `additional-message` 섹션 필터링 로직 제거





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 리뷰 대화 상자 인터페이스에 사용자 정의 헤더 추가로 닫기 기능 제공
  * 상담 형식에서 이전에 건너뛴 섹션을 포함한 모든 섹션의 렌더링 지원

* **Style**
  * 헤더 영역의 배경 색상 및 모서리 반지름 스타일 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->