### PR TITLE
refactor: ConfirmDialog 공통화 및 ExitConfirmDialog 래핑 리팩토링

### DIFF
--- a/src/components/confirm-dialog.tsx
+++ b/src/components/confirm-dialog.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, cloneElement, isValidElement } from 'react';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -14,38 +15,119 @@ import { cn } from '@/api/utils';
 import ErrorIcon from '@/assets/icons/error';
 
 interface ConfirmDialogProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+  /**
+   * 다이얼로그 열림 상태 (선택적)
+   */
+  open?: boolean;
+  /**
+   * 다이얼로그 열림 상태 변경 시 호출되는 함수 (선택적)
+   */
+  onOpenChange?: (open: boolean) => void;
+  /**
+   * 확인 버튼 클릭 시 실행할 함수
+   */
   onConfirm: () => void;
+  /**
+   * 취소 버튼 클릭 시 실행할 함수
+   */
   onCancel?: () => void;
+  /**
+   * 다이얼로그 제목
+   */
   title: string;
-  description: string;
+  /**
+   * 다이얼로그 설명
+   */
+  description: React.ReactNode;
+  /**
+   * 확인 버튼 텍스트 (기본값: '확인')
+   */
   confirmText?: string;
+  /**
+   * 취소 버튼 텍스트 (기본값: '취소')
+   */
   cancelText?: string;
+  /**
+   * 데이터가 있는지 확인하는 함수 또는 boolean 값 (선택적)
+   * 설정하면 hasData가 true일 때만 다이얼로그를 표시
+   */
+  hasData?: boolean | (() => boolean);
+  /**
+   * 다이얼로그 트리거 역할을 할 자식 요소 (선택적)
+   * children의 onClick에 다이얼로그 열기 로직이 자동으로 추가됨
+   */
+  children?: React.ReactNode;
 }
 
 export default function ConfirmDialog({
-  open,
-  onOpenChange,
+  open: controlledOpen,
+  onOpenChange: controlledOnOpenChange,
   onConfirm,
   onCancel,
   title,
   description,
   confirmText = '확인',
   cancelText = '취소',
+  hasData,
+  children,
 }: ConfirmDialogProps) {
+  const [internalOpen, setInternalOpen] = useState(false);
+
+  // 외부 제어 또는 내부 제어
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : internalOpen;
+  const setOpen = isControlled && controlledOnOpenChange ? controlledOnOpenChange : setInternalOpen;
+
+  const check = () => (hasData !== undefined ? (typeof hasData === 'function' ? hasData() : hasData) : true);
+
+  // 트리거 클릭 시 호출
+  const handleTrigger = () => {
+    if (check()) {
+      setOpen(true);
+    } else {
+      // hasData가 false면 바로 confirm 실행
+      onConfirm();
+    }
+  };
+
   const handleConfirm = () => {
-    onOpenChange(false);
+    setOpen(false);
     onConfirm();
   };
 
   const handleCancel = () => {
-    onOpenChange(false);
+    setOpen(false);
     onCancel?.();
   };
 
+  // children이 있으면 클론하여 onClick 이벤트 추가
+  const triggerElement =
+    children && isValidElement(children)
+      ? cloneElement(
+          children as React.ReactElement<{
+            onClick?: (e: React.MouseEvent) => void;
+          }>,
+          {
+            onClick: (e: React.MouseEvent) => {
+              const originalOnClick = (
+                children as React.ReactElement<{
+                  onClick?: (e: React.MouseEvent) => void;
+                }>
+              ).props?.onClick;
+              if (originalOnClick) {
+                originalOnClick(e);
+              }
+              handleTrigger();
+            },
+          },
+        )
+      : children;
+
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
+    <>
+      {triggerElement}
+
+      <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogPortal>
         <AlertDialogOverlay className="bg-[var(--color-alpha-dimmer)]" />
         <AlertDialogPrimitive.Content
@@ -94,5 +176,6 @@ export default function ConfirmDialog({
         </AlertDialogPrimitive.Content>
       </AlertDialogPortal>
     </AlertDialog>
+    </>
   );
 }

--- a/src/components/exit-confirmation-dialog.tsx
+++ b/src/components/exit-confirmation-dialog.tsx
@@ -1,19 +1,7 @@
 'use client';
 
-import { useState, cloneElement, isValidElement } from 'react';
 import { useRouter } from 'next/navigation';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogDescription,
-  AlertDialogOverlay,
-  AlertDialogPortal,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
-import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
-import { cn } from '@/api/utils';
-import ErrorIcon from '@/assets/icons/error';
+import ConfirmDialog from './confirm-dialog';
 
 interface ExitConfirmDialogProps {
   /**
@@ -21,7 +9,7 @@ interface ExitConfirmDialogProps {
    */
   hasData: boolean | (() => boolean);
   /**
-   * 확인 시 실행할 함수 (기본값: router.back())
+   * 확인 시 실행할 함수 (기본값: router.push('/'))
    */
   onConfirm?: () => void;
   /**
@@ -44,40 +32,19 @@ interface ExitConfirmDialogProps {
 
 /**
  * 페이지 이탈 시 확인 다이얼로그를 표시하는 재사용 가능한 컴포넌트
+ * ConfirmDialog를 래핑하여 이탈 확인 전용 텍스트를 제공합니다.
  */
 export default function ExitConfirmDialog({
   hasData,
   onConfirm,
   onCancel,
   children,
-  open: controlledOpen,
-  onOpenChange: controlledOnOpenChange,
+  open,
+  onOpenChange,
 }: ExitConfirmDialogProps) {
   const router = useRouter();
-  const [internalOpen, setInternalOpen] = useState(false);
 
-  // 외부 제어 또는 내부 제어
-  const isControlled = controlledOpen !== undefined;
-  const open = isControlled ? controlledOpen : internalOpen;
-  const setOpen = isControlled && controlledOnOpenChange ? controlledOnOpenChange : setInternalOpen;
-
-  const check = () => (typeof hasData === 'function' ? hasData() : hasData);
-
-  // 페이지 이동 시 호출 (예: 뒤로가기 버튼, router.push)
-  const handleExit = () => {
-    if (check()) {
-      setOpen(true);
-    } else {
-      if (onConfirm) {
-        onConfirm();
-      } else {
-        router.back();
-      }
-    }
-  };
-
-  const confirm = () => {
-    setOpen(false);
+  const handleConfirm = () => {
     if (onConfirm) {
       onConfirm();
     } else {
@@ -85,89 +52,20 @@ export default function ExitConfirmDialog({
     }
   };
 
-  const cancel = () => {
-    setOpen(false);
-    onCancel?.();
-  };
-
-  // children이 있으면 클론하여 onClick 이벤트 추가
-  const triggerElement =
-    children && isValidElement(children)
-      ? cloneElement(
-          children as React.ReactElement<{
-            onClick?: (e: React.MouseEvent) => void;
-          }>,
-          {
-            onClick: (e: React.MouseEvent) => {
-              const originalOnClick = (
-                children as React.ReactElement<{
-                  onClick?: (e: React.MouseEvent) => void;
-                }>
-              ).props?.onClick;
-              if (originalOnClick) {
-                originalOnClick(e);
-              }
-              handleExit();
-            },
-          },
-        )
-      : children;
-
   return (
-    <>
-      {triggerElement}
-
-      <AlertDialog open={open} onOpenChange={setOpen}>
-        <AlertDialogPortal>
-          <AlertDialogOverlay className="bg-[var(--color-alpha-dimmer)]" />
-          <AlertDialogPrimitive.Content
-            className={cn(
-              'bg-white data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 flex flex-col w-full max-w-[360px] translate-x-[-50%] translate-y-[-50%] rounded-[16px] shadow-lg duration-200 overflow-hidden',
-            )}
-          >
-            {/* 상단 영역 */}
-            <div className="flex flex-col gap-3 items-center pb-4 pt-8 px-4">
-              {/* 경고 아이콘 */}
-              <div className="relative size-[60px] flex items-center justify-center">
-                <div className="absolute size-[53.33px] bg-[var(--color-status-error-100)] rounded-full" />
-                <div className="absolute size-[26.67px] flex items-center justify-center">
-                  <ErrorIcon className="size-full" />
-                </div>
-              </div>
-
-              {/* 텍스트 영역 */}
-              <div className="flex flex-col gap-1.5 items-center text-center w-full">
-                <AlertDialogTitle className="text-body-l font-semibold leading-[32px] text-grayscale-black mb-0">
-                  입력한 내용이 사라져요!
-                </AlertDialogTitle>
-                <AlertDialogDescription className="text-body-s font-normal leading-[24px] text-grayscale-gray6 mt-0">
-                  지금 화면을 벗어나면
-                  <br />
-                  입력한 내용이 사라지며, 복구할 수 없어요.
-                </AlertDialogDescription>
-              </div>
-            </div>
-
-            {/* 하단 버튼 영역 */}
-            <div className="flex flex-col gap-3 items-center justify-end pb-5 pt-4 px-4">
-              <div className="flex gap-2 w-full">
-                <AlertDialogCancel
-                  onClick={cancel}
-                  className="flex-1 h-12 bg-[var(--color-secondary-100)] text-[#4F3B2E] rounded-lg px-4 py-3 text-body-s font-semibold border-0"
-                >
-                  이어서 작성
-                </AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={confirm}
-                  className="flex-1 h-12 bg-[#4F3B2E] text-[var(--color-secondary-500)] hover:bg-[#4F3B2E] hover:text-[var(--color-secondary-500)] rounded-lg px-4 py-3 text-body-s font-semibold"
-                >
-                  작성 중단
-                </AlertDialogAction>
-              </div>
-            </div>
-          </AlertDialogPrimitive.Content>
-        </AlertDialogPortal>
-      </AlertDialog>
-    </>
+    <ConfirmDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      onConfirm={handleConfirm}
+      onCancel={onCancel}
+      hasData={hasData}
+      title="입력한 내용이 사라져요!"
+      description={`지금 화면을 벗어나면
+입력한 내용이 사라지며, 복구할 수 없어요.`}
+      confirmText="작성 중단"
+      cancelText="이어서 작성"
+    >
+      {children}
+    </ConfirmDialog>
   );
 }

--- a/src/components/ui/simple-dialog/simple-dialog.tsx
+++ b/src/components/ui/simple-dialog/simple-dialog.tsx
@@ -69,7 +69,7 @@ function SimpleDialogTitle({ className, ...props }: React.ComponentProps<typeof 
 }
 
 function SimpleDialogDescription({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Description>) {
-  return <DialogDescription className={cn('text-body-s', className)} {...props} />;
+  return <DialogDescription className={cn('text-body-s whitespace-pre-line', className)} {...props} />;
 }
 
 export {

--- a/src/stories/components/confirm-dialog.stories.tsx
+++ b/src/stories/components/confirm-dialog.stories.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import ConfirmDialog from './confirm-dialog';
+import ConfirmDialog from '@/components/confirm-dialog';
+import { Button } from '@/components/ui/button';
 
 const meta = {
   title: 'components/confirm-dialog',
@@ -22,4 +23,57 @@ export const Default: Story = {
     title: '확인 다이얼로그',
     description: '정말 진행하시겠습니까?',
   },
+};
+
+export const WithCustomText: Story = {
+  args: {
+    open: true,
+    onOpenChange: () => {},
+    onConfirm: () => {},
+    title: '삭제하시겠습니까?',
+    description: '삭제된 내용은 복구할 수 없어요.',
+    confirmText: '삭제',
+    cancelText: '취소',
+  },
+};
+
+export const WithTrigger = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <ConfirmDialog
+      open={open}
+      onOpenChange={setOpen}
+      onConfirm={() => {
+        alert('확인되었습니다!');
+        setOpen(false);
+      }}
+      title="확인이 필요해요"
+      description="정말 진행하시겠습니까?"
+    >
+      <Button>다이얼로그 열기</Button>
+    </ConfirmDialog>
+  );
+};
+
+export const WithHasData = () => {
+  const [hasData, setHasData] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-4 items-center">
+      <label className="flex items-center gap-2">
+        <input type="checkbox" checked={hasData} onChange={(e) => setHasData(e.target.checked)} />
+        데이터 있음
+      </label>
+
+      <ConfirmDialog
+        hasData={hasData}
+        onConfirm={() => alert('확인되었습니다!')}
+        title="데이터가 있어요"
+        description="hasData가 true일 때만 다이얼로그가 표시됩니다."
+      >
+        <Button>클릭해보세요</Button>
+      </ConfirmDialog>
+    </div>
+  );
 };


### PR DESCRIPTION
### 작업 내용

- `ConfirmDialog`를 외부 제어/내부 제어 모두 가능한 구조로 확장
- `description` 타입을 `ReactNode`로 변경하고, `hasData`, `children`(trigger) 지원 추가
- `ExitConfirmDialog` 내부 구현을 제거하고 `ConfirmDialog` 래핑 방식으로 리팩토링
- `SimpleDialogDescription`에 `whitespace-pre-line` 적용해 줄바꿈 렌더링 개선









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 확인 대화상자가 외부 제어 또는 내부 상태 관리를 지원합니다.
  * hasData 속성으로 데이터 존재 여부에 따라 대화상자 표시를 조건부로 제어할 수 있습니다.
  * 자동 트리거 연결을 통해 더 유연한 대화상자 상호작용이 가능합니다.
  * 종료 확인 대화상자가 외부 상태 제어를 지원합니다.

* **스타일**
  * 대화상자 설명의 줄 바꿈이 올바르게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->