### PR TITLE
design : 필터 UI 수정

### DIFF
--- a/src/app/(main)/inquiries/_components/inquiry-sort-bar.tsx
+++ b/src/app/(main)/inquiries/_components/inquiry-sort-bar.tsx
@@ -32,17 +32,24 @@ export default function InquirySortBar({ currentSort, onSortChange }: InquirySor
     <div className="flex items-center justify-between w-full">
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="text" className="gap-1 -mx-3 -my-2">
+          <Button
+            variant="ghost"
+            className="gap-1 px-0 py-0 h-auto bg-transparent text-grayscale-gray6 text-body-xs font-medium [&_svg]:text-current hover:bg-transparent hover:text-grayscale-gray6 data-[state=open]:bg-transparent data-[state=open]:text-grayscale-gray6"
+          >
             <Sort className="size-5" />
             {currentLabel}
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent>
+        <DropdownMenuContent
+          align="start"
+          sideOffset={8}
+          className="w-[9.5625rem] bg-white rounded-[4px] p-1 shadow-[0px_0px_13px_0px_rgba(12,17,29,0.08)] min-w-0 border-0"
+        >
           {SORT_OPTIONS.map((opt) => (
             <DropdownMenuItem
               key={opt.value}
               onSelect={() => onSortChange(opt.value)}
-              className={cn({ 'font-bold text-primary-500': opt.value === currentSort })}
+              className="px-2.5 py-2 text-body-xs font-medium text-grayscale-gray6 rounded-[4px] hover:bg-tertiary-500 focus:bg-tertiary-500 focus:text-grayscale-gray6"
             >
               {opt.label}
             </DropdownMenuItem>


### PR DESCRIPTION
### 작업 내용

## 정렬 필터 드롭다운 Figma 디자인 반영
  - 트리거: 배경색 없음, 아이콘과 드롭다운 왼쪽 정렬
  - 드롭다운: 너비 9.5625rem, 호버/포커스 시 Tertiary/500 배경만 적용


### 연관 이슈

관련이슈 번호를 close해주세요.
예시 close #1
