### PR TITLE
feat : (질문) 상세페이지 추가

### DIFF
--- a/src/app/(main)/explore/breeder/[id]/_components/empty-pet-state.tsx
+++ b/src/app/(main)/explore/breeder/[id]/_components/empty-pet-state.tsx
@@ -1,12 +1,14 @@
 import Image from 'next/image';
 
-export default function EmptyPetState() {
+interface EmptyPetStateProps {
+  message?: string;
+}
+
+export default function EmptyPetState({ message = '곧 새로운 아이가 등록될 예정이에요' }: EmptyPetStateProps) {
   return (
     <div className="flex flex-col items-center gap-[1.75rem]">
       <Image src="/dog-and-cat.svg" alt="강아지와 고양이" width={320} height={141} className="w-auto h-auto" />
-      <p className="text-grayscale-gray5 text-body-l font-semibold leading-[2rem] text-center">
-        곧 새로운 아이가 등록될 예정이에요
-      </p>
+      <p className="text-grayscale-gray5 text-body-l font-semibold leading-[2rem] text-center">{message}</p>
     </div>
   );
 }

--- a/src/app/(main)/inquiries/[id]/_components/inquiry-detail-actions.tsx
+++ b/src/app/(main)/inquiries/[id]/_components/inquiry-detail-actions.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import Pencil from '@/assets/icons/pencil.svg';
+import Trash from '@/assets/icons/trash-1.svg';
+import { Button } from '@/components/ui/button';
+
+interface InquiryDetailActionsProps {
+  onEdit?: () => void;
+  onDelete?: () => void;
+}
+
+export default function InquiryDetailActions({ onEdit, onDelete }: InquiryDetailActionsProps) {
+  return (
+    <div className="flex gap-2 items-center shrink-0">
+      {onEdit && (
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={onEdit}
+          className="gap-1.5 py-2 pl-3 pr-2"
+        >
+          수정
+          <Pencil aria-hidden />
+        </Button>
+      )}
+      {onDelete && (
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={onDelete}
+          className="gap-1.5 py-2 pl-3 pr-2"
+        >
+          삭제
+          <Trash aria-hidden />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/app/(main)/inquiries/[id]/_components/inquiry-detail-content.tsx
+++ b/src/app/(main)/inquiries/[id]/_components/inquiry-detail-content.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import InquiryAnswer from '../../_components/inquiry-answer';
+import { Separator } from '@/components/ui/separator';
+import type { Inquiry } from '../../_types/inquiry';
+import InquiryDetailActions from '@/app/(main)/inquiries/[id]/_components/inquiry-detail-actions';
+import InquiryDetailHeader from './inquiry-detail-header';
+import InquiryDetailMeta from './inquiry-detail-meta';
+import InquiryWaitingAnswer from './inquiry-waiting-answer';
+
+interface InquiryDetailContentProps {
+  inquiry: Inquiry;
+  onEdit?: () => void;
+  onDelete?: () => void;
+}
+
+export default function InquiryDetailContent({ inquiry, onEdit, onDelete }: InquiryDetailContentProps) {
+  const hasAnswers = inquiry.answerCount > 0 && (inquiry.answers?.length ?? 0) > 0;
+  const answers = inquiry.answers ?? (inquiry.latestAnswer ? [inquiry.latestAnswer] : []);
+
+  return (
+    <div className="flex flex-col gap-6 w-full">
+      <InquiryDetailHeader inquiry={inquiry} />
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <InquiryDetailMeta inquiry={inquiry} />
+        <InquiryDetailActions onEdit={onEdit} onDelete={onDelete} />
+      </div>
+
+      <Separator className="bg-grayscale-gray3" />
+
+      {hasAnswers ? (
+        <div className="flex flex-col gap-3">
+          {answers.map((answer, index) => (
+            <InquiryAnswer key={`${answer.breederName}-${answer.answeredAt}-${index}`} answer={answer} />
+          ))}
+        </div>
+      ) : (
+        <InquiryWaitingAnswer />
+      )}
+    </div>
+  );
+}

--- a/src/app/(main)/inquiries/[id]/_components/inquiry-detail-header.tsx
+++ b/src/app/(main)/inquiries/[id]/_components/inquiry-detail-header.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import Image from 'next/image';
+import { ANIMAL_TAB_ITEMS } from '@/components/animal-tab-bar';
+import type { Inquiry } from '../../_types/inquiry';
+
+interface InquiryDetailHeaderProps {
+  inquiry: Inquiry;
+}
+
+export default function InquiryDetailHeader({ inquiry }: InquiryDetailHeaderProps) {
+  const animalItem = ANIMAL_TAB_ITEMS.find((item) => item.type === inquiry.animalType);
+  const Icon = animalItem?.icon ?? ANIMAL_TAB_ITEMS[0].icon;
+  const animalName = animalItem?.name ?? '강아지';
+
+  const imageUrls = inquiry.imageUrls ?? [];
+  const gridCount = Math.min(4, Math.max(0, imageUrls.length) || 4);
+
+  return (
+    <div className="flex flex-col gap-4 w-full">
+      <div className="flex gap-2 items-center">
+        <Icon className="size-5 text-grayscale-gray6" aria-hidden />
+        <span className="text-body-s font-medium text-grayscale-gray6">{animalName}</span>
+      </div>
+
+      <h1 className="text-heading-2 font-bold text-primary-500">{inquiry.title}</h1>
+
+      <p className="text-body-m font-normal text-grayscale-gray6 whitespace-pre-wrap">{inquiry.content}</p>
+
+      {gridCount > 0 && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 w-full">
+          {Array.from({ length: gridCount }).map((_, i) => (
+            <div
+              key={i}
+              className="relative aspect-square w-full rounded-lg overflow-hidden bg-grayscale-gray2 bg-[length:16px_16px] bg-[image:repeating-conic-gradient(#e5e5e5_0_25%,transparent_0_50%)]"
+              role="img"
+              aria-label={imageUrls[i] ? `첨부 이미지 ${i + 1}` : '이미지 없음'}
+            >
+              {imageUrls[i] ? (
+                <Image
+                  src={imageUrls[i]}
+                  alt=""
+                  fill
+                  sizes="(max-width: 640px) 100vw, 50vw"
+                  className="object-cover rounded-lg"
+                />
+              ) : null}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(main)/inquiries/[id]/_components/inquiry-detail-meta.tsx
+++ b/src/app/(main)/inquiries/[id]/_components/inquiry-detail-meta.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import type { Inquiry } from '../../_types/inquiry';
+
+interface InquiryDetailMetaProps {
+  inquiry: Inquiry;
+}
+
+export default function InquiryDetailMeta({ inquiry }: InquiryDetailMetaProps) {
+  const author = inquiry.authorNickname ?? '입양자';
+  const date = inquiry.createdAt;
+  const viewCount = inquiry.viewCount ?? 0;
+
+  return (
+    <div className="flex gap-2 items-center text-body-s font-normal text-grayscale-gray5">
+      <span>{author}</span>
+      <span aria-hidden>·</span>
+      <span>{date}</span>
+      <span aria-hidden>·</span>
+      <span>조회수 {viewCount}</span>
+    </div>
+  );
+}

--- a/src/app/(main)/inquiries/[id]/_components/inquiry-waiting-answer.tsx
+++ b/src/app/(main)/inquiries/[id]/_components/inquiry-waiting-answer.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import EmptyPetState from '@/app/(main)/explore/breeder/[id]/_components/empty-pet-state';
+
+export default function InquiryWaitingAnswer() {
+  return (
+    <div className="py-10">
+      <EmptyPetState message="아직 답변을 기다리고 있어요" />
+    </div>
+  );
+}

--- a/src/app/(main)/inquiries/[id]/page.tsx
+++ b/src/app/(main)/inquiries/[id]/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useParams, useRouter } from 'next/navigation';
+import Container from '@/components/ui/container';
+import { useInquiryDetail } from '../_hooks/use-inquiry-detail';
+import { LoadingText } from '@/components/loading-state';
+import InquiryDetailContent from './_components/inquiry-detail-content';
+
+export default function InquiryDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const id = typeof params?.id === 'string' ? params.id : null;
+  const { data: inquiry, isLoading, isError } = useInquiryDetail(id);
+
+  const handleEdit = () => {
+    if (id) router.push(`/inquiries/${id}/edit`);
+  };
+  const handleDelete = () => {
+    if (id && typeof window !== 'undefined' && window.confirm('이 질문을 삭제할까요?')) {
+      // TODO: 삭제 API 연동 후 목록으로 이동
+      router.push('/inquiries');
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Container className="py-6">
+        <div className="flex justify-center py-12">
+          <LoadingText className="text-body-m text-grayscale-gray5" />
+        </div>
+      </Container>
+    );
+  }
+
+  if (isError || !inquiry) {
+    return (
+      <Container className="py-6">
+        <div className="flex flex-col items-center justify-center py-12 gap-2">
+          <p className="text-body-m text-grayscale-gray5">질문을 찾을 수 없어요.</p>
+          <a href="/inquiries" className="text-body-m font-medium text-primary-500 underline">
+            질문 목록으로
+          </a>
+        </div>
+      </Container>
+    );
+  }
+
+  return (
+    <Container className="pb-20 pt-6 md:pt-7 lg:pt-10">
+      <InquiryDetailContent inquiry={inquiry} onEdit={handleEdit} onDelete={handleDelete} />
+    </Container>
+  );
+}

--- a/src/app/(main)/inquiries/_hooks/use-inquiry-detail.ts
+++ b/src/app/(main)/inquiries/_hooks/use-inquiry-detail.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import type { Inquiry } from '../_types/inquiry';
+
+/**
+ * TODO: 실제 API 연결 시 fetchInquiryDetail를 API 호출로 교체
+ */
+const fetchInquiryDetail = async (id: string): Promise<Inquiry | null> => {
+  await new Promise((resolve) => setTimeout(resolve, 200));
+
+  const mock: Inquiry = {
+    id,
+    title: '리트리버 입양 전, 마당 펜스 높이는 어느 정도가 안전할까요?',
+    content:
+      '아이와 함께 자랄 대형견을 찾다가 리트리버 입양을 결정했습니다. 단독주택이라 마당에서 뛰어 놀게 하고 싶은데, 활동량이 워낙 많다고 들어서 담장 너머로 점프하거나 탈출하지 않을까 걱정됩니다. 안전한 펜스 높이와 바닥 재질 추천 부탁드려요!',
+    type: 'common',
+    animalType: 'dog',
+    viewCount: 42,
+    answerCount: 0,
+    createdAt: '2025. 02. 15.',
+    authorNickname: '입양자 닉네임',
+    imageUrls: ['', '', '', ''], // 2x2 placeholder
+  };
+
+  if (id === 'inquiry-2' || id.startsWith('inquiry-')) {
+    return mock;
+  }
+  return null;
+};
+
+export function useInquiryDetail(id: string | null) {
+  return useQuery({
+    queryKey: ['inquiry', id],
+    queryFn: () => fetchInquiryDetail(id!),
+    enabled: !!id,
+  });
+}

--- a/src/app/(main)/inquiries/_types/inquiry.ts
+++ b/src/app/(main)/inquiries/_types/inquiry.ts
@@ -19,6 +19,12 @@ export interface Inquiry {
   answerCount: number;
   latestAnswer?: InquiryAnswer;
   createdAt: string;
+  /** 상세 페이지용: 작성자 닉네임 */
+  authorNickname?: string;
+  /** 상세 페이지용: 첨부 이미지 URL 목록 */
+  imageUrls?: string[];
+  /** 상세 페이지용: 답변 전체 목록 (상세에서만 사용) */
+  answers?: InquiryAnswer[];
 }
 
 export type InquirySortType = 'latest_answer' | 'latest' | 'most_viewed';

--- a/src/assets/icons/trash-1.svg
+++ b/src/assets/icons/trash-1.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.75 3.625V12.375C11.75 12.6875 11.4375 13 11.125 13H7.99998H4.875C4.5625 13 4.25 12.6875 4.25 12.375V3.625" stroke="#545454" stroke-width="0.96" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3 3.625H13" stroke="#545454" stroke-width="0.96" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6.75 3H9.24999M6.75 6.12499V10.5M9.24999 6.12499V10.5" stroke="#545454" stroke-width="0.96" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/animal-tab-bar/index.ts
+++ b/src/components/animal-tab-bar/index.ts
@@ -1,1 +1,1 @@
-export { default as AnimalTabBar, type AnimalType } from './animal-tab-bar';
+export { default as AnimalTabBar, ANIMAL_TAB_ITEMS, type AnimalType } from './animal-tab-bar';


### PR DESCRIPTION
### 작업 내용


## 질문 상세 페이지(`/inquiries/[id]`)
  - 카테고리, 제목, 본문, 2×2 이미지 그리드 (sm에서 1열)
  - 메타(작성자·날짜·조회수), 수정/삭제 버튼 
  - 답변 대기 시 EmptyPetState 사용



### 연관 이슈

관련이슈 번호를 close해주세요.
예시 close #1
