### PR TITLE
design : (상담 신청폼 편집) 헤더 텍스트 추가

### DIFF
--- a/src/app/(main)/modify-counselform/_components/counsel-form-content.tsx
+++ b/src/app/(main)/modify-counselform/_components/counsel-form-content.tsx
@@ -93,6 +93,17 @@ function CounselFormContentInner() {
       <FormLayout hasFormData={hasFormData} isLgUp={isLgUp}>
         <div className="w-full lg:w-1/2 flex flex-col">
           <div className="flex w-full flex-col items-center pb-20 md:pb-24  md:px-4 lg:px-0.5">
+            {/* 페이지 헤더 */}
+            <div className="flex flex-col items-center gap-3 pb-15 text-center">
+              <h2 className="text-heading-2 font-semibold text-primary-500 whitespace-pre-line">
+                {'입양 희망자에게 궁금한 질문을 추가해\n맞춤 신청서를 만들어 주세요.'}
+              </h2>
+              <p className="text-body-m font-medium text-grayscale-gray6">
+                기본 필수 질문 외에{' '}
+                <span className="text-[#4e9cf1]">브리더님만의 질문</span>
+                을 자유롭게 추가할 수 있어요.
+              </p>
+            </div>
             {COUNSEL_SECTIONS.map((section, index) => {
               const isLast = index === COUNSEL_SECTIONS.length - 1;
 


### PR DESCRIPTION
### 작업 내용
## 헤더 텍스트 추가
입양 희망자에게 궁금한 질문을 추가해 맞춤 신청서를 만들어 주세요.
기본 필수 질문 외에 브리더님만의 질문을 자유롭게 추가할 수 있어요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 상담 폼 페이지에 새로운 헤더 UI 블록 추가
  * 중앙 정렬된 제목과 설명 텍스트를 포함한 페이지 헤더 구성
  * 개선된 시각적 계층 구조로 사용자 경험 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->