### PR TITLE
feat: 브리더 신청 목록을 채팅 진입형 UI로 수정/ 신청서 조회 모달 연동

### DIFF
--- a/src/app/(main)/application/_components/chat/chat-input.tsx
+++ b/src/app/(main)/application/_components/chat/chat-input.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState, useRef, useCallback } from 'react';
+
+interface ChatInputProps {
+  onSend: (content: string) => Promise<void> | void;
+  disabled?: boolean;
+}
+
+export function ChatInput({ onSend, disabled }: ChatInputProps) {
+  const [value, setValue] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleSend = useCallback(async () => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    await onSend(trimmed);
+    setValue('');
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+    }
+  }, [value, onSend]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setValue(e.target.value);
+    const el = e.target;
+    el.style.height = 'auto';
+    el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
+  };
+
+  return (
+    <div className="bg-white border-t border-grayscale-gray2 px-4 py-3">
+      <div className="flex items-end gap-2">
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={handleInput}
+          onKeyDown={handleKeyDown}
+          placeholder="메시지를 입력하세요"
+          disabled={disabled}
+          rows={1}
+          className="
+            flex-1 resize-none overflow-hidden rounded-xl border border-grayscale-gray2 bg-grayscale-gray1
+            px-4 py-2.5 text-body-s text-grayscale-gray7
+            placeholder:text-grayscale-gray4
+            focus:outline-none focus:border-primary-500
+            disabled:opacity-50 disabled:cursor-not-allowed
+          "
+        />
+        <button
+          type="button"
+          onClick={handleSend}
+          disabled={disabled || !value.trim()}
+          className="
+            shrink-0 h-10 px-4 rounded-xl
+            bg-primary-500 text-white text-body-s font-medium
+            hover:bg-primary-600 transition-colors
+            disabled:bg-status-disabled disabled:text-grayscale-gray4 disabled:cursor-not-allowed
+          "
+        >
+          전송
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/application/_components/chat/chat-message-area.tsx
+++ b/src/app/(main)/application/_components/chat/chat-message-area.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import type { ChatMessage } from '../../_types/chat';
+
+interface ChatMessageAreaProps {
+  messages: ChatMessage[];
+}
+
+function formatTime(date: Date): string {
+  return date.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false });
+}
+
+function SystemMessage({ message }: { message: ChatMessage }) {
+  return (
+    <div className="flex justify-center px-4 py-2">
+      <div className="bg-tertiary-600/70 rounded-full px-4 py-2 max-w-[80%]">
+        <p className="text-caption text-grayscale-gray6 text-center">{message.content}</p>
+      </div>
+    </div>
+  );
+}
+
+function BreederBubble({ message }: { message: ChatMessage }) {
+  return (
+    <div className="flex justify-start gap-2 px-4">
+      <div className="max-w-[75%]">
+        <div className="bg-white rounded-2xl rounded-tl-sm px-4 py-3">
+          <p className="text-body-s text-grayscale-gray7 whitespace-pre-wrap">{message.content}</p>
+        </div>
+        <span className="text-[11px] text-grayscale-gray4 mt-1 block">{formatTime(new Date(message.timestamp))}</span>
+      </div>
+    </div>
+  );
+}
+
+function AdopterBubble({ message }: { message: ChatMessage }) {
+  return (
+    <div className="flex justify-end gap-2 px-4">
+      <div className="max-w-[75%]">
+        <div className="bg-primary-500 rounded-2xl rounded-tr-sm px-4 py-3">
+          <p className="text-body-s text-white whitespace-pre-wrap">{message.content}</p>
+        </div>
+        <span className="text-[11px] text-grayscale-gray4 mt-1 block text-right">{formatTime(new Date(message.timestamp))}</span>
+      </div>
+    </div>
+  );
+}
+
+export function ChatMessageArea({ messages }: ChatMessageAreaProps) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const currentUser: ChatMessage['senderId'] = 'breeder';
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages.length]);
+
+  return (
+    <div className="flex-1 overflow-y-auto py-4 flex flex-col gap-3">
+      {messages.map((msg) => {
+        if (msg.senderId === 'system') {
+          return <SystemMessage key={msg.id} message={msg} />;
+        }
+
+        const isOutgoing = msg.senderId === currentUser;
+        if (isOutgoing) {
+          return <AdopterBubble key={msg.id} message={msg} />;
+        }
+
+        switch (msg.senderId) {
+          case 'breeder':
+          case 'adopter':
+            return <BreederBubble key={msg.id} message={msg} />;
+          default:
+            return null;
+        }
+      })}
+      <div ref={bottomRef} />
+    </div>
+  );
+}

--- a/src/app/(main)/application/_components/chat/chat-room.tsx
+++ b/src/app/(main)/application/_components/chat/chat-room.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useCallback } from 'react';
+import type { ApplicationItem } from '../../_hooks/use-applications';
+import { useChatRoom } from '../../_hooks/use-chat-room';
+import { ChatMessageArea } from './chat-message-area';
+import { ChatInput } from './chat-input';
+
+interface ChatRoomProps {
+  application: ApplicationItem;
+}
+
+export function ChatRoom({ application }: ChatRoomProps) {
+  const { messages, sendMessage, isSending } = useChatRoom(application.applicationId);
+
+  const handleSend = useCallback(
+    async (content: string) => {
+      await sendMessage(content);
+    },
+    [sendMessage],
+  );
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0 bg-tertiary-500">
+      <ChatMessageArea messages={messages} />
+      <ChatInput onSend={handleSend} disabled={isSending} />
+    </div>
+  );
+}

--- a/src/app/(main)/application/_components/chat/chat-sidebar.tsx
+++ b/src/app/(main)/application/_components/chat/chat-sidebar.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import type { ApplicationItem } from '../../_hooks/use-applications';
+
+interface ChatSidebarProps {
+  applications: ApplicationItem[];
+  activeId: string;
+  width: number;
+}
+
+export function ChatSidebar({ applications, activeId, width }: ChatSidebarProps) {
+  return (
+    <div
+      className="hidden md:flex md:flex-col border-r border-grayscale-gray2 bg-white shrink-0"
+      style={{ width }}
+    >
+      <div className="px-4 pt-5 pb-3 border-b border-tertiary-600">
+        <h2 className="text-body-m font-semibold text-primary-500">채팅 목록</h2>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {applications.map((app) => {
+          const isActive = activeId === app.applicationId;
+          return (
+            <Link
+              key={app.applicationId}
+              href={`/application/chat/${app.applicationId}`}
+              className={`
+                block w-full px-4 py-3 border-b border-tertiary-600 transition-colors
+                ${isActive ? 'bg-tertiary-500' : 'hover:bg-grayscale-gray1'}
+              `}
+            >
+              <p className="text-body-s font-semibold text-primary-500 truncate">
+                {app.adopterName || '입양 신청자'}
+              </p>
+              <p className="text-caption text-grayscale-gray5 truncate mt-0.5">
+                {app.preferredPetInfo || app.petName || '분양 중인 아이'}
+              </p>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/application/_components/detail/application-detail-modal.tsx
+++ b/src/app/(main)/application/_components/detail/application-detail-modal.tsx
@@ -17,9 +17,10 @@ interface ApplicationDetailModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   applicationId: string;
+  showActions?: boolean;
 }
 
-const ApplicationDetailModal = ({ open, onOpenChange, applicationId }: ApplicationDetailModalProps) => {
+const ApplicationDetailModal = ({ open, onOpenChange, applicationId, showActions = true }: ApplicationDetailModalProps) => {
   const {
     data: application,
     isLoading,
@@ -62,12 +63,10 @@ const ApplicationDetailModal = ({ open, onOpenChange, applicationId }: Applicati
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className={`${dialogContentClass} p-0 gap-0 bg-white flex flex-col`}>
-        <VisuallyHidden>
-          <DialogTitle>입양 신청 상세</DialogTitle>
-        </VisuallyHidden>
-
-        {/* 상단 구분선 */}
-        <Separator className="bg-[#E1E1E1]" />
+        <div className="px-6 py-4 border-b border-[#E1E1E1] bg-white">
+          <DialogTitle className="text-lg font-semibold text-[#4F3B2E]">받은 신청서</DialogTitle>
+          <VisuallyHidden>입양 신청 상세</VisuallyHidden>
+        </div>
 
         {/* 스크롤 영역 */}
         <div className="overflow-y-auto bg-[#F6F6EA] px-6 py-5 flex-1">
@@ -102,61 +101,66 @@ const ApplicationDetailModal = ({ open, onOpenChange, applicationId }: Applicati
           )}
         </div>
 
-        {/* 하단 구분선 */}
         <Separator className="bg-[#E1E1E1]" />
 
         {/* 하단 버튼 영역 (브리더용) */}
         {application && (
           <div className="bg-white px-6 py-4 rounded-b-none md:rounded-2xl flex items-center justify-between">
-            {application.status !== 'consultation_completed' && (
-              <div className="flex items-center gap-1">
-                <svg
-                  width="12"
-                  height="12"
-                  viewBox="0 0 12 12"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="shrink-0"
-                >
-                  <circle cx="6" cy="6" r="5" fill="#A0A0A0" />
-                  <path
-                    d="M6 3.5V6.5M6 8.5H6.005"
-                    stroke="white"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-                <p className="text-xs text-[#A0A0A0]">
-                  상담이 끝나면 [상담 완료]를 눌러 상대방이 후기를 남길 수 있게 해주세요.
-                </p>
-              </div>
-            )}
-            {application.status === 'consultation_completed' ? (
-              <div className="flex items-center gap-2 ml-auto">
-                <Button
-                  variant="tertiary"
-                  className="h-9 px-4 bg-[#A0C8F4] hover:bg-[#77B2F3] text-[#4F3B2E] text-sm font-medium rounded"
-                  onClick={handleCancelConsultation}
-                  disabled={updateStatusMutation.isPending}
-                >
-                  완료 취소
-                </Button>
-                <Button
-                  disabled
-                  className="h-9 px-4 bg-[#E1E1E1] text-[#A0A0A0] text-sm font-medium rounded min-w-[72px] cursor-not-allowed"
-                >
-                  상담 완료
-                </Button>
-              </div>
+            {showActions ? (
+              <>
+                {application.status !== 'consultation_completed' && (
+                  <div className="flex items-center gap-1">
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 12 12"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="shrink-0"
+                    >
+                      <circle cx="6" cy="6" r="5" fill="#A0A0A0" />
+                      <path
+                        d="M6 3.5V6.5M6 8.5H6.005"
+                        stroke="white"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                    <p className="text-xs text-[#A0A0A0]">
+                      상담이 끝나면 [상담 완료]를 눌러 상대방이 후기를 남길 수 있게 해주세요.
+                    </p>
+                  </div>
+                )}
+                {application.status === 'consultation_completed' ? (
+                  <div className="flex items-center gap-2 ml-auto">
+                    <Button
+                      variant="tertiary"
+                      className="h-9 px-4 bg-[#A0C8F4] hover:bg-[#77B2F3] text-[#4F3B2E] text-sm font-medium rounded"
+                      onClick={handleCancelConsultation}
+                      disabled={updateStatusMutation.isPending}
+                    >
+                      완료 취소
+                    </Button>
+                    <Button
+                      disabled
+                      className="h-9 px-4 bg-[#E1E1E1] text-[#A0A0A0] text-sm font-medium rounded min-w-[72px] cursor-not-allowed"
+                    >
+                      상담 완료
+                    </Button>
+                  </div>
+                ) : (
+                  <Button
+                    className="h-9 px-4 bg-[#4F3B2E] hover:bg-[#3E2F23] text-white text-sm font-medium rounded min-w-[72px] ml-auto"
+                    onClick={handleCompleteConsultation}
+                    disabled={updateStatusMutation.isPending}
+                  >
+                    상담 완료
+                  </Button>
+                )}
+              </>
             ) : (
-              <Button
-                className="h-9 px-4 bg-[#4F3B2E] hover:bg-[#3E2F23] text-white text-sm font-medium rounded min-w-[72px] ml-auto"
-                onClick={handleCompleteConsultation}
-                disabled={updateStatusMutation.isPending}
-              >
-                상담 완료
-              </Button>
+              <div className="ml-auto h-9" />
             )}
           </div>
         )}

--- a/src/app/(main)/application/_components/shared/application-list-item.tsx
+++ b/src/app/(main)/application/_components/shared/application-list-item.tsx
@@ -140,13 +140,16 @@ export default function ApplicationListItem({
     return (
       <>
         <div
-          className="bg-[#F8F8EE] flex flex-col gap-3 p-5 rounded-lg w-full cursor-pointer hover:bg-[#F0F0E5] transition-colors"
+          className="bg-[#F8F8EE] flex flex-col p-5 rounded-lg w-full cursor-pointer hover:bg-[#F0F0E5] transition-colors"
           onClick={() => setIsModalOpen(true)}
         >
           {/* 신청자 정보 */}
           <div className="flex flex-col gap-1 w-full">
-            {/* 신청자 닉네임 */}
-            <h3 className="text-body-m font-medium text-[#4F3B2E]">{adopterName}</h3>
+            {/* 신청자 닉네임 + 날짜 */}
+            <div className="flex items-center justify-between">
+              <h3 className="text-body-m font-medium text-[#4F3B2E]">{adopterName}</h3>
+              <p className="text-body-s font-normal text-[#888888] shrink-0">{applicationDate}</p>
+            </div>
 
             {/* 분양 중인 아이 정보 (드롭다운 선택 또는 직접 입력 텍스트) */}
             <p className="text-body-s font-normal text-[#888888] overflow-ellipsis overflow-hidden whitespace-nowrap">
@@ -154,11 +157,7 @@ export default function ApplicationListItem({
             </p>
           </div>
 
-          {/* 뱃지 + 날짜 */}
-          <div className="flex items-center gap-3">
-            <ApplicationStatusBadge status={status} />
-            <p className="text-body-s font-normal text-[#888888]">{applicationDate}</p>
-          </div>
+       
         </div>
 
         {/* 상세보기 모달 */}

--- a/src/app/(main)/application/_components/shared/application-status-badge.tsx
+++ b/src/app/(main)/application/_components/shared/application-status-badge.tsx
@@ -23,12 +23,7 @@ export function ApplicationStatusBadge({ status, size = 'default' }: Application
 
   switch (status) {
     case 'consultation_pending':
-      return (
-        <Badge className="bg-[#A0C8F4] text-[#4F3B2E] hover:bg-[#A0C8F4] h-7 px-3 py-1.5 gap-1.5 rounded-full flex items-center">
-          <ConsultationPendingIcon />
-          <span className="text-caption font-medium">상담 전</span>
-        </Badge>
-      );
+      return null;
     case 'consultation_completed':
       return (
         <Badge className="bg-[#A0A0A0] text-white hover:bg-[#A0A0A0] h-7 px-3 py-1.5 gap-1.5 rounded-full flex items-center">

--- a/src/app/(main)/application/_hooks/use-chat-room.ts
+++ b/src/app/(main)/application/_hooks/use-chat-room.ts
@@ -1,0 +1,48 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { getApplicationChatMessages, sendApplicationChatMessage } from '@/api/breeder';
+import type { ChatMessage } from '../_types/chat';
+
+async function fetchChatMessages(applicationId: string): Promise<ChatMessage[]> {
+  const messages = await getApplicationChatMessages(applicationId);
+  return messages.map((message) => ({
+    id: message.messageId,
+    senderId: message.senderRole,
+    content: message.content,
+    timestamp: message.sentAt,
+  }));
+}
+
+async function sendChatMessage(applicationId: string, content: string): Promise<void> {
+  await sendApplicationChatMessage(applicationId, { content });
+}
+
+export function useChatRoom(applicationId: string) {
+  const queryClient = useQueryClient();
+
+  const messagesQuery = useQuery({
+    queryKey: ['chat-messages', applicationId],
+    queryFn: () => fetchChatMessages(applicationId),
+    enabled: !!applicationId,
+  });
+
+  const sendMessageMutation = useMutation({
+    mutationFn: (content: string) => sendChatMessage(applicationId, content),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['chat-messages', applicationId] });
+    },
+  });
+
+  // TODO(socket): applicationId room 구독 추가
+  // - 소켓 이벤트 수신 시 queryClient.setQueryData로 메시지 캐시 즉시 반영
+  // - 연결 해제/재연결 처리 및 unread 카운트 정책 연결
+
+  return {
+    messages: messagesQuery.data ?? [],
+    isLoadingMessages: messagesQuery.isLoading,
+    sendMessage: sendMessageMutation.mutateAsync,
+    isSending: sendMessageMutation.isPending,
+  };
+}
+

--- a/src/app/(main)/application/_hooks/use-resize-panel.ts
+++ b/src/app/(main)/application/_hooks/use-resize-panel.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+interface UseResizePanelOptions {
+  defaultWidth?: number;
+  minWidth?: number;
+  maxWidth?: number;
+}
+
+export function useResizePanel({
+  defaultWidth = 300,
+  minWidth = 220,
+  maxWidth = 480,
+}: UseResizePanelOptions = {}) {
+  const [width, setWidth] = useState(defaultWidth);
+  const isDragging = useRef(false);
+
+  const handleMouseDown = useCallback(() => {
+    isDragging.current = true;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  }, []);
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!isDragging.current) return;
+      setWidth(Math.min(maxWidth, Math.max(minWidth, e.clientX)));
+    };
+
+    const handleMouseUp = () => {
+      if (!isDragging.current) return;
+      isDragging.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [minWidth, maxWidth]);
+
+  return { width, handleMouseDown };
+}

--- a/src/app/(main)/application/_types/chat.ts
+++ b/src/app/(main)/application/_types/chat.ts
@@ -1,0 +1,7 @@
+export interface ChatMessage {
+  id: string;
+  senderId: 'breeder' | 'adopter' | 'system';
+  content: string;
+  timestamp: string | Date;
+}
+

--- a/src/app/(main)/application/chat/[applicationId]/page.tsx
+++ b/src/app/(main)/application/chat/[applicationId]/page.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useState } from 'react';
+import { useAuthGuard } from '@/hooks/use-auth-guard';
+import { useApplications } from '../../_hooks/use-applications';
+import { useResizePanel } from '../../_hooks/use-resize-panel';
+import { ChatRoom } from '../../_components/chat/chat-room';
+import { ChatSidebar } from '../../_components/chat/chat-sidebar';
+import { LoadingState } from '@/components/loading-state';
+import LeftArrow from '@/assets/icons/left-arrow.svg';
+import ApplicationDetailModal from '../../_components/detail/application-detail-modal';
+import { Button } from '@/components/ui/button';
+
+export default function ChatPage() {
+  useAuthGuard();
+  const { applicationId } = useParams<{ applicationId: string }>();
+  const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
+  const { data } = useApplications();
+  const { width, handleMouseDown } = useResizePanel();
+
+  const allApplications = data?.pages.flatMap((page) => page.data) ?? [];
+  const application = allApplications.find((app) => app.applicationId === applicationId);
+
+  if (!data) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-white">
+        <LoadingState />
+      </div>
+    );
+  }
+
+  if (!application) {
+    return (
+      <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-white">
+        <p className="text-body-s text-grayscale-gray5">신청을 찾을 수 없습니다.</p>
+        <Link href="/application" className="text-body-s text-primary-500 underline">
+          목록으로 돌아가기
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex bg-white">
+      {/* 좌측 사이드바 - 데스크톱 */}
+      <ChatSidebar applications={allApplications} activeId={applicationId} width={width} />
+
+      {/* 리사이즈 핸들 - 데스크톱 */}
+      <div
+        className="hidden md:flex w-1 cursor-col-resize items-center justify-center hover:bg-grayscale-gray2 active:bg-grayscale-gray3 transition-colors group shrink-0"
+        onMouseDown={handleMouseDown}
+      >
+        <div className="w-0.5 h-8 rounded-full bg-grayscale-gray3 group-hover:bg-grayscale-gray4 transition-colors" />
+      </div>
+
+      {/* 채팅방 */}
+      <div className="flex-1 flex flex-col min-w-0">
+        <div className="flex items-center gap-2 h-14 px-3 bg-white border-b border-grayscale-gray2 shrink-0">
+          <Link href="/application" className="flex items-center justify-center w-8 h-8">
+            <LeftArrow className="text-primary-500" />
+          </Link>
+          <span className="flex h-8 items-center text-body-m leading-none font-semibold text-primary-500">
+            {application.adopterName || '입양 신청자'}
+          </span>
+          <Button
+            type="button"
+            variant="tertiary"
+            className="ml-auto h-8 px-3 py-0 text-caption"
+            onClick={() => setIsDetailModalOpen(true)}
+          >
+            신청서 보기
+          </Button>
+        </div>
+        <ChatRoom application={application} />
+      </div>
+      <ApplicationDetailModal
+        open={isDetailModalOpen}
+        onOpenChange={setIsDetailModalOpen}
+        applicationId={applicationId}
+        showActions={false}
+      />
+    </div>
+  );
+}

--- a/src/app/(main)/application/page.tsx
+++ b/src/app/(main)/application/page.tsx
@@ -1,23 +1,26 @@
 'use client';
 
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import Container from '@/components/ui/container';
 import { Separator } from '@/components/ui/separator';
 import ApplicationListItem from './_components/shared/application-list-item';
+import { ApplicationStatusBadge } from './_components/shared/application-status-badge';
 import LoadMoreButton from '@/components/ui/load-more-button';
 import { useApplications } from './_hooks/use-applications';
 import { useAuthGuard } from '@/hooks/use-auth-guard';
 import { useAuthStore } from '@/stores/auth-store';
 import { getUserRoleFromCookie } from '@/api/cookie-utils';
-import { useState, useEffect } from 'react';
 import { LoadingState } from '@/components/loading-state';
+import ApplicationDetailModal from './_components/detail/application-detail-modal';
+import { Button } from '@/components/ui/button';
 
-const ApplicationPage = () => {
-  useAuthGuard(); // 인증 체크만 수행
+export default function ApplicationPage() {
+  useAuthGuard();
   const { user } = useAuthStore();
   const [isBreeder, setIsBreeder] = useState(false);
   const [isMounted, setIsMounted] = useState(false);
 
-  // 클라이언트 마운트 후에만 role 결정 (Hydration 에러 방지)
   useEffect(() => {
     const cookieRole = getUserRoleFromCookie();
     const userRole = cookieRole || user?.role;
@@ -25,65 +28,130 @@ const ApplicationPage = () => {
     setIsMounted(true);
   }, [user?.role]);
 
+  if (!isMounted) return null;
+
+  return isBreeder ? <BreederApplicationList /> : <AdopterApplicationList />;
+}
+
+function BreederApplicationList() {
+  const router = useRouter();
+  const [selectedApplicationId, setSelectedApplicationId] = useState<string | null>(null);
+  const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useApplications();
   const allApplications = data?.pages.flatMap((page) => page.data) ?? [];
-
-  const handleLoadMore = () => {
-    if (hasNextPage && !isFetchingNextPage) {
-      fetchNextPage();
-    }
-  };
-
-  // 페이지 제목을 role에 따라 다르게 표시
-  const pageTitle = isBreeder ? '받은 신청' : '신청 내역';
-  const emptyMessage = isBreeder ? '받은 신청이 없습니다.' : '신청 내역이 없습니다.';
-
-  // 초기 마운트 대기 (Hydration 에러 방지)
-  if (!isMounted) {
-    return null;
-  }
 
   return (
     <Container>
       <div className="flex-1 @container flex flex-col gap-6 md:gap-7 lg:gap-10 pt-10 pb-20">
-        <div className="text-[#4F3B2E] text-heading-3 font-semibold">{pageTitle}</div>
+        <div className="text-primary-500 text-heading-3 font-semibold">받은 신청</div>
 
         {!data ? (
           <LoadingState />
         ) : allApplications.length === 0 ? (
           <div className="flex justify-center py-20">
-            <p className="text-body-s text-grayscale-gray5">{emptyMessage}</p>
+            <p className="text-body-s text-grayscale-gray5">받은 신청이 없습니다.</p>
+          </div>
+        ) : (
+          <>
+            <div className="flex flex-col gap-3">
+              {allApplications.map((app) => (
+                <div
+                  key={app.applicationId}
+                  className="bg-tertiary-500 flex flex-col p-5 rounded-lg w-full cursor-pointer hover:bg-tertiary-600 transition-colors"
+                  onClick={() => router.push(`/application/chat/${app.applicationId}`)}
+                >
+                  <div className="grid grid-cols-[1fr_auto] grid-rows-2 items-start gap-x-3 gap-y-1 w-full">
+                    <h3 className="text-body-m font-medium text-primary-500 truncate">
+                      {app.adopterName || '입양 신청자'}
+                    </h3>
+                    <p className="text-body-s font-normal text-grayscale-gray5 shrink-0 text-right">{app.applicationDate}</p>
+                    <p className="text-body-s font-normal text-grayscale-gray5 overflow-ellipsis overflow-hidden whitespace-nowrap">
+                      {app.preferredPetInfo || app.petName || '분양 중인 아이 정보'}
+                    </p>
+                    <div className="flex justify-end">
+                      <Button
+                        type="button"
+                        variant="tertiary"
+                        className="h-7 px-2.5 py-0 text-caption"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedApplicationId(app.applicationId);
+                          setIsDetailModalOpen(true);
+                        }}
+                      >
+                        신청서 보기
+                      </Button>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <ApplicationStatusBadge status={app.status} />
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {hasNextPage && (
+              <LoadMoreButton
+                onClick={() => hasNextPage && !isFetchingNextPage && fetchNextPage()}
+                isLoading={isFetchingNextPage}
+                variant="custom"
+              />
+            )}
+          </>
+        )}
+      </div>
+      {selectedApplicationId && (
+        <ApplicationDetailModal
+          open={isDetailModalOpen}
+          onOpenChange={setIsDetailModalOpen}
+          applicationId={selectedApplicationId}
+          showActions={false}
+        />
+      )}
+    </Container>
+  );
+}
+
+function AdopterApplicationList() {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useApplications();
+  const allApplications = data?.pages.flatMap((page) => page.data) ?? [];
+
+  return (
+    <Container>
+      <div className="flex-1 @container flex flex-col gap-6 md:gap-7 lg:gap-10 pt-10 pb-20">
+        <div className="text-primary-500 text-heading-3 font-semibold">신청 내역</div>
+
+        {!data ? (
+          <LoadingState />
+        ) : allApplications.length === 0 ? (
+          <div className="flex justify-center py-20">
+            <p className="text-body-s text-grayscale-gray5">신청 내역이 없습니다.</p>
           </div>
         ) : (
           <>
             <div className="flex flex-col gap-3">
               {allApplications.map((item, index) => (
                 <div key={item.applicationId || `application-${index}`}>
-                  {isBreeder ? (
-                    // 브리더 모드(받은 신청): py 없음, separator 없음
-                    <ApplicationListItem {...item} isBreeder={isBreeder} />
-                  ) : (
-                    // 입양자 모드(신청 내역): separator에만 py-[28px]
-                    <>
-                      <ApplicationListItem {...item} isBreeder={isBreeder} />
-                      {index < allApplications.length - 1 && (
-                        <div className="py-[28px]">
-                          <Separator className="bg-grayscale-gray2" />
-                        </div>
-                      )}
-                    </>
+                  <ApplicationListItem {...item} isBreeder={false} />
+                  {index < allApplications.length - 1 && (
+                    <div className="py-[28px]">
+                      <Separator className="bg-grayscale-gray2" />
+                    </div>
                   )}
                 </div>
               ))}
             </div>
 
-            {/* 더보기 버튼 */}
-            {hasNextPage && <LoadMoreButton onClick={handleLoadMore} isLoading={isFetchingNextPage} variant="custom" />}
+            {hasNextPage && (
+              <LoadMoreButton
+                onClick={() => hasNextPage && !isFetchingNextPage && fetchNextPage()}
+                isLoading={isFetchingNextPage}
+                variant="custom"
+              />
+            )}
           </>
         )}
       </div>
     </Container>
   );
-};
-
-export default ApplicationPage;
+}

--- a/src/app/api/application.ts
+++ b/src/app/api/application.ts
@@ -2,19 +2,19 @@ import apiClient from './api';
 
 /** 입양 신청 요청 데이터 */
 export interface ApplicationCreateRequest {
-  name: string;
-  phone: string;
-  email: string;
+  name?: string;
+  phone?: string;
+  email?: string;
   breederId: string;
   petId?: string;
   privacyConsent: boolean;
-  selfIntroduction: string;
+  selfIntroduction?: string;
   familyMembers: string;
   allFamilyConsent: boolean;
-  allergyTestInfo: string;
-  timeAwayFromHome: string;
-  livingSpaceDescription: string;
-  previousPetExperience: string;
+  allergyTestInfo?: string;
+  timeAwayFromHome?: string;
+  livingSpaceDescription?: string;
+  previousPetExperience?: string;
   canProvideBasicCare: boolean;
   canAffordMedicalExpenses: boolean;
   preferredPetDescription?: string;

--- a/src/app/api/breeder.ts
+++ b/src/app/api/breeder.ts
@@ -566,6 +566,24 @@ export interface ApplicationStatusUpdateResponseDto {
   message: string;
 }
 
+/** 브리더 채팅 메시지 DTO */
+export interface BreederChatMessageDto {
+  messageId: string;
+  senderRole: 'breeder' | 'adopter' | 'system';
+  content: string;
+  sentAt: string;
+}
+
+interface ChatMessagesResponseData {
+  messages?: BreederChatMessageDto[];
+  items?: BreederChatMessageDto[];
+}
+
+/** 채팅 메시지 전송 요청 DTO */
+export interface SendBreederChatMessageRequestDto {
+  content: string;
+}
+
 /**
  * 입양 신청 상태 업데이트 (브리더용)
  * PATCH /api/breeder-management/applications/:applicationId
@@ -591,5 +609,69 @@ export const updateApplicationStatus = async (
       throw error;
     }
     throw new Error('Unknown error during application status update');
+  }
+};
+
+/**
+ * 신청별 채팅 메시지 조회 (브리더용)
+ * GET /api/breeder-management/applications/:applicationId/chat/messages
+ */
+export const getApplicationChatMessages = async (applicationId: string): Promise<BreederChatMessageDto[]> => {
+  try {
+    const response = await apiClient.get<ApiResponse<BreederChatMessageDto[] | ChatMessagesResponseData>>(
+      `/api/breeder-management/applications/${applicationId}/chat/messages`,
+    );
+
+    if (!response.data.success || !response.data.data) {
+      throw new Error(response.data.message || 'Failed to fetch chat messages');
+    }
+
+    if (Array.isArray(response.data.data)) {
+      return response.data.data;
+    }
+
+    if ('messages' in response.data.data && Array.isArray(response.data.data.messages)) {
+      return response.data.data.messages;
+    }
+
+    if ('items' in response.data.data && Array.isArray(response.data.data.items)) {
+      return response.data.data.items;
+    }
+
+    return [];
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error('Fetch chat messages error:', error.message);
+      throw error;
+    }
+    throw new Error('Unknown error during chat messages fetch');
+  }
+};
+
+/**
+ * 신청별 채팅 메시지 전송 (브리더용)
+ * POST /api/breeder-management/applications/:applicationId/chat/messages
+ */
+export const sendApplicationChatMessage = async (
+  applicationId: string,
+  requestData: SendBreederChatMessageRequestDto,
+): Promise<BreederChatMessageDto | null> => {
+  try {
+    const response = await apiClient.post<ApiResponse<BreederChatMessageDto>>(
+      `/api/breeder-management/applications/${applicationId}/chat/messages`,
+      requestData,
+    );
+
+    if (!response.data.success) {
+      throw new Error(response.data.message || 'Failed to send chat message');
+    }
+
+    return response.data.data ?? null;
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.error('Send chat message error:', error.message);
+      throw error;
+    }
+    throw new Error('Unknown error during chat message send');
   }
 };


### PR DESCRIPTION
### 작업 내용


- 브리더 `받은 신청` 목록을 채팅방 진입 구조로 수정 / 신청 클릭 시 `/application/chat/[applicationId]` 라우트로 이동하도록 변경
- 채팅 화면에 좌측 채팅 목록(데스크톱), 리사이즈 패널, 채팅 메시지/입력 UI를 구성하고 `신청서 보기` 버튼으로 신청서 상세 모달을 열 수 있도록 연결
- 신청서 상세 모달에 조회 전용 모드(`showActions`)를 추가해 채팅/목록 화면에서도 공통 모달을 재사용 가능하게 개선
- 채팅  `useChatRoom` + `breeder API`  소켓 연동 준비






### 연관 이슈

관련이슈 번호를 close해주세요.
예시 close #395 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 신청서별 실시간 채팅 기능 추가
* 채팅 목록 사이드바 및 메시지 자동 스크롤 기능
* 채팅 패널 크기 조정 기능

## 개선 사항

* 신청서 목록 UI 레이아웃 개선
* 신청서 상세 모달 헤더 및 액션 영역 개선

## 변경 사항

* 신청서 작성 시 선택 입력 필드 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->