### PR TITLE
refactor: FCM 토큰 등록 주체를 프론트에서 RN으로 변경

### DIFF
--- a/src/app/api/notification.ts
+++ b/src/app/api/notification.ts
@@ -148,15 +148,3 @@ export async function deleteNotification(notificationId: string): Promise<void> 
     throw new Error(response.data.error || '알림 삭제에 실패했습니다.');
   }
 }
-
-/**
- * FCM 푸시 토큰 등록
- * @param token FCM 디바이스 토큰
- */
-export async function registerPushToken(token: string): Promise<void> {
-  const response = await api.post<ApiResponse<null>>('/api/notification/push-token', { token });
-
-  if (!response.data.success) {
-    throw new Error(response.data.error || 'FCM 토큰 등록에 실패했습니다.');
-  }
-}

--- a/src/app/login/success/page.tsx
+++ b/src/app/login/success/page.tsx
@@ -5,8 +5,6 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuthStore } from '@/stores/auth-store';
 import { useAnalytics } from '@/hooks/use-analytics';
 import { LoadingState } from '@/components/loading-state';
-import { registerPushToken } from '@/app/api/notification';
-
 /**
  * 소셜 로그인 성공 후 토큰을 쿠키에 저장하는 페이지
  *
@@ -17,24 +15,11 @@ import { registerPushToken } from '@/app/api/notification';
  * - Next.js 15에서 Server Component에서는 쿠키 수정 불가
  * - 브라우저에서 직접 fetch해야 Set-Cookie 헤더가 적용됨
  */
-function requestAndRegisterFcmToken() {
+function requestAndRegisterFcmToken(accessToken: string) {
+  console.log('[FCM] requestAndRegisterFcmToken 진입');
   if (typeof window === 'undefined' || !window.ReactNativeWebView) return;
 
-  const timeout = setTimeout(() => {
-    delete window.__onFCMToken;
-  }, 5000);
-
-  window.__onFCMToken = async (token: string) => {
-    clearTimeout(timeout);
-    delete window.__onFCMToken;
-    try {
-      await registerPushToken(token);
-    } catch {
-      // FCM 등록 실패는 로그인 flow를 막지 않음
-    }
-  };
-
-  window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'REQUEST_FCM_TOKEN' }));
+  window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'REQUEST_FCM_TOKEN', accessToken }));
 }
 
 function LoginSuccessContent() {
@@ -93,7 +78,7 @@ function LoginSuccessContent() {
           // 로그인 성공 - returnUrl이 있으면 그곳으로, 없으면 홈으로 이동
           const returnUrl = searchParams.get('returnUrl') || '/';
 
-          requestAndRegisterFcmToken();
+          requestAndRegisterFcmToken(accessToken);
           router.replace(returnUrl);
         } else {
           console.error('쿠키 설정 실패');

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -2,5 +2,4 @@ interface Window {
   ReactNativeWebView?: {
     postMessage: (message: string) => void;
   };
-  __onFCMToken?: (token: string) => void;
 }


### PR DESCRIPTION
### 작업 내용
- accessToken을 postMessage에 포함하여 RN이 백엔드에 직접 등록
- window.__onFCMToken 콜백, 타임아웃 로직 제거
- 사용하지 않는 registerPushToken() API 함수 제거
- 진입 확인용 console.log 추가

### 연관 이슈

관련이슈 번호를 close해주세요.
예시 close #399 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 푸시 알림 토큰 등록 메커니즘이 업데이트되었습니다.
  * 알림 조회, 미읽음 수 조회, 읽음 처리, 삭제 기능은 계속 정상 작동합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pawpong/pawpong_frontend/pull/401)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->